### PR TITLE
fix: Remove dev-only dependency

### DIFF
--- a/packages/network-of-terms-graphql/test/server.test.ts
+++ b/packages/network-of-terms-graphql/test/server.test.ts
@@ -5,7 +5,7 @@ import {teardown} from 'jest-dev-server';
 import {
   startDistributionSparqlEndpoint,
   testCatalog,
-} from '@netwerk-digitaal-erfgoed/network-of-terms-query';
+} from '../../network-of-terms-query/src/server-test';
 
 let httpServer: FastifyInstance;
 const catalog = testCatalog(3000);

--- a/packages/network-of-terms-query/src/index.ts
+++ b/packages/network-of-terms-query/src/index.ts
@@ -5,7 +5,6 @@ export * from './terms';
 export * from './search/query-mode';
 export * from './distributions';
 export * from './helpers/logger';
-export * from './server-test';
 
 import {newEngine} from '@comunica/actor-init-sparql';
 

--- a/packages/network-of-terms-reconciliation/test/server.test.ts
+++ b/packages/network-of-terms-reconciliation/test/server.test.ts
@@ -4,9 +4,9 @@ import {customRequest, server} from '../src/server';
 import {teardown} from 'jest-dev-server';
 import {ReconciliationQueryBatch} from '../src/query';
 import {
-  testCatalog,
   startDistributionSparqlEndpoint,
-} from '@netwerk-digitaal-erfgoed/network-of-terms-query';
+  testCatalog,
+} from '../../network-of-terms-query/src/server-test';
 
 let httpServer: FastifyInstance<Server, customRequest>;
 const catalog = testCatalog(3001);


### PR DESCRIPTION
server-test.ts has dependencies on libraries that are available only in
dev (such as jest-dev-server), so it must not be imported by
network-of-terms-query's index.ts.

Remove that import and replace it in the tests with a relative include.
