### PR TITLE
chore: Enforce Node version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
* Enable engine strict to prevent installing dependencies when Node
  version does not match `engine`.
* Use `engine-strict` in `.npmrc` because the `engineStrict` option in
  `package.json` is ignored.
