### PR TITLE
feat: Support source authentication

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,10 +15,10 @@ export default {
   ],
   coverageThreshold: {
     global: {
-      lines: 88.14,
-      statements: 88.02,
-      branches: 92.08,
-      functions: 85.71,
+      lines: 88.35,
+      statements: 88.23,
+      branches: 92.36,
+      functions: 85.98,
     },
   },
   transform: {},

--- a/packages/network-of-terms-catalog/catalog/datasets/gtaa-classificatie.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/gtaa-classificatie.jsonld
@@ -20,7 +20,7 @@
     {
       "@id": "https://data.beeldengeluid.nl/id/datadownload/0027",
       "@type": "DataDownload",
-      "contentUrl": "https://gtaa.apis.beeldengeluid.nl/sparql",
+      "contentUrl": "https://$GTAA_CREDENTIALS@gtaa.apis.beeldengeluid.nl/sparql",
       "encodingFormat": "application/sparql-query",
       "potentialAction": [
         {

--- a/packages/network-of-terms-catalog/catalog/datasets/gtaa-genres.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/gtaa-genres.jsonld
@@ -20,7 +20,7 @@
     {
       "@id": "https://data.beeldengeluid.nl/id/datadownload/0028",
       "@type": "DataDownload",
-      "contentUrl": "https://gtaa.apis.beeldengeluid.nl/sparql",
+      "contentUrl": "https://$GTAA_CREDENTIALS@gtaa.apis.beeldengeluid.nl/sparql",
       "encodingFormat": "application/sparql-query",
       "potentialAction": [
         {

--- a/packages/network-of-terms-catalog/catalog/datasets/gtaa-geografische-namen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/gtaa-geografische-namen.jsonld
@@ -20,7 +20,7 @@
     {
       "@id": "https://data.beeldengeluid.nl/id/datadownload/0029",
       "@type": "DataDownload",
-      "contentUrl": "https://gtaa.apis.beeldengeluid.nl/sparql",
+      "contentUrl": "https://$GTAA_CREDENTIALS@gtaa.apis.beeldengeluid.nl/sparql",
       "encodingFormat": "application/sparql-query",
       "potentialAction": [
         {

--- a/packages/network-of-terms-catalog/catalog/datasets/gtaa-namen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/gtaa-namen.jsonld
@@ -20,7 +20,7 @@
     {
       "@id": "https://data.beeldengeluid.nl/id/datadownload/0030",
       "@type": "DataDownload",
-      "contentUrl": "https://gtaa.apis.beeldengeluid.nl/sparql",
+      "contentUrl": "https://$GTAA_CREDENTIALS@gtaa.apis.beeldengeluid.nl/sparql",
       "encodingFormat": "application/sparql-query",
       "potentialAction": [
         {

--- a/packages/network-of-terms-catalog/catalog/datasets/gtaa-onderwerpen-beng.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/gtaa-onderwerpen-beng.jsonld
@@ -20,7 +20,7 @@
     {
       "@id": "https://data.beeldengeluid.nl/id/datadownload/0032",
       "@type": "DataDownload",
-      "contentUrl": "https://gtaa.apis.beeldengeluid.nl/sparql",
+      "contentUrl": "https://$GTAA_CREDENTIALS@gtaa.apis.beeldengeluid.nl/sparql",
       "encodingFormat": "application/sparql-query",
       "potentialAction": [
         {

--- a/packages/network-of-terms-catalog/catalog/datasets/gtaa-onderwerpen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/gtaa-onderwerpen.jsonld
@@ -20,7 +20,7 @@
     {
       "@id": "https://data.beeldengeluid.nl/id/datadownload/0031",
       "@type": "DataDownload",
-      "contentUrl": "https://gtaa.apis.beeldengeluid.nl/sparql",
+      "contentUrl": "https://$GTAA_CREDENTIALS@gtaa.apis.beeldengeluid.nl/sparql",
       "encodingFormat": "application/sparql-query",
       "potentialAction": [
         {

--- a/packages/network-of-terms-catalog/catalog/datasets/gtaa-persoonsnamen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/gtaa-persoonsnamen.jsonld
@@ -20,7 +20,7 @@
     {
       "@id": "https://data.beeldengeluid.nl/id/datadownload/0026",
       "@type": "DataDownload",
-      "contentUrl": "https://gtaa.apis.beeldengeluid.nl/sparql",
+      "contentUrl": "https://$GTAA_CREDENTIALS@gtaa.apis.beeldengeluid.nl/sparql",
       "encodingFormat": "application/sparql-query",
       "potentialAction": [
         {

--- a/packages/network-of-terms-catalog/test/catalog.test.ts
+++ b/packages/network-of-terms-catalog/test/catalog.test.ts
@@ -4,7 +4,9 @@ import {
   IRI,
   SparqlDistribution,
 } from '@netwerk-digitaal-erfgoed/network-of-terms-query';
-import {defaultCatalog} from '../src';
+import {defaultCatalog, fromFile, fromStore} from '../src';
+import {dirname, resolve} from 'path';
+import {fileURLToPath} from 'url';
 
 let catalog: Catalog;
 
@@ -65,5 +67,23 @@ describe('Catalog', () => {
     );
     expect(rkd).toBeInstanceOf(Dataset);
     expect(rkd?.iri).toEqual(new IRI('https://data.rkd.nl/rkdartists'));
+  });
+
+  it('substitutes credentials from environment variables', async () => {
+    process.env.DATASET_CREDENTIALS = 'username:password';
+    const store = await fromFile(
+      resolve(
+        dirname(fileURLToPath(import.meta.url)),
+        'fixtures/credentials.jsonld'
+      )
+    );
+    const catalog = await fromStore([store]);
+    const distributionIri = new IRI(
+      'https://data.beeldengeluid.nl/id/datadownload/0027'
+    );
+    const dataset = catalog.getDatasetByDistributionIri(distributionIri)!;
+    expect(
+      dataset.getDistributionByIri(distributionIri)?.endpoint.toString()
+    ).toEqual('https://username:password@gtaa.apis.beeldengeluid.nl/sparql');
   });
 });

--- a/packages/network-of-terms-catalog/test/fixtures/credentials.jsonld
+++ b/packages/network-of-terms-catalog/test/fixtures/credentials.jsonld
@@ -1,0 +1,40 @@
+{
+  "@context": "https://schema.org/docs/jsonldcontext.jsonld",
+  "@id": "http://data.beeldengeluid.nl/gtaa/Classificatie",
+  "@type": "Dataset",
+  "name": [
+    {
+      "@language": "nl",
+      "@value": "GTAA: classificatie"
+    }
+  ],
+  "creator": [
+    {
+      "@id": "https://www.beeldengeluid.nl/",
+      "@type": "Organization",
+      "name": "Nederlands Instituut voor Beeld en Geluid",
+      "alternateName": "Beeld en Geluid"
+    }
+  ],
+  "url": [
+    "http://data.beeldengeluid.nl/gtaa/"
+  ],
+  "distribution": [
+    {
+      "@id": "https://data.beeldengeluid.nl/id/datadownload/0027",
+      "@type": "DataDownload",
+      "contentUrl": "https://$DATASET_CREDENTIALS@gtaa.apis.beeldengeluid.nl/sparql",
+      "encodingFormat": "application/sparql-query",
+      "potentialAction": [
+        {
+          "@type": "SearchAction",
+          "query": "query"
+        },
+        {
+          "@type": "FindAction",
+          "query": "query"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Substitute variables (`$DATASET_CREDENTIALS`) in `contentUrl` with
  value from environment variable.
* If no corresponding environment variable is found, substitute with
  empty string.

Fix #478.
