### PR TITLE
optimized query for gtaa persoonsnamen

### DIFF
--- a/packages/network-of-terms-catalog/catalog/queries/search/gtaa-persoonsnamen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/gtaa-persoonsnamen.rq
@@ -1,55 +1,28 @@
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX justskos: <http://justskos.org/ns/core#>
-
 CONSTRUCT {
     ?uri a skos:Concept ;
         skos:prefLabel ?prefLabel ;
         skos:altLabel ?altLabel ;
         skos:hiddenLabel ?hiddenLabel ;
-        skos:scopeNote ?scopeNote ;
-        skos:broader ?broader_uri ;
-        skos:narrower ?narrower_uri ;
-        skos:related ?related_uri .
-    ?broader_uri skos:prefLabel ?broader_prefLabel .
-    ?narrower_uri skos:prefLabel ?narrower_prefLabel .
-    ?related_uri skos:prefLabel ?related_prefLabel .
+        skos:scopeNote ?scopeNote . 
+
 }
 WHERE {
-    {
-        ?uri skos:inScheme <http://data.beeldengeluid.nl/gtaa/Persoonsnamen> .
-        ?uri skos:prefLabel|skos:altLabel|skos:hiddenLabel ?label ;
-            justskos:status ?status .
-        FILTER(LANG(?label) = "nl")
-        FILTER(?status IN ('approved', 'candidate'))
+    ?uri skos:inScheme <http://data.beeldengeluid.nl/gtaa/Persoonsnamen> .
+    ?uri skos:prefLabel|skos:altLabel|skos:hiddenLabel ?label ;
+        justskos:status ?status .
+        
+    FILTER(LANG(?label) = "nl")
+    FILTER(?status IN ('approved', 'candidate'))
 
-        # single word query, match case insensitive
-        FILTER regex(?query, "^[^ ]+$")
-        FILTER CONTAINS(LCASE(?label), LCASE(?query))
-    }
-# commented because of timeouts
-#    UNION
-#    {
-#        ?uri skos:inScheme <http://data.beeldengeluid.nl/gtaa/Persoonsnamen> .
-#        ?uri ?predicate ?label ;
-#            justskos:status ?status .
-#        VALUES ?predicate { skos:prefLabel skos:altLabel skos:hiddenLabel }
-#        FILTER(LANG(?label) = "nl")
-#        FILTER(?status IN ('approved', 'candidate'))
-#        
-#        # double word query, whitespace separator
-#        FILTER REGEX(?query, "^([^ ]+)[ ]+([^ ]+)$")
-#
-#        BIND(REPLACE(?query, "^([^ ]+)[ ]+([^ ]+)$", "$1") AS ?term1)
-#        BIND(REPLACE(?query, "^([^ ]+)[ ]+([^ ]+)$", "$2") AS ?term2)
-#
-#        # search case insensitive using an AND construct for the query terms
-#        FILTER( CONTAINS(LCASE(?label), LCASE(?term1)) && CONTAINS(LCASE(?label), LCASE(?term2)) )
-#    }
+    # single word query
+    FILTER regex(?query, "^[^ ]+$")
+    FILTER CONTAINS(LCASE(?label), LCASE(?query))
 
-    OPTIONAL {
-        ?uri skos:prefLabel ?prefLabel .
-        FILTER(LANG(?prefLabel) = "nl" )
-    }
+    ?uri skos:prefLabel ?prefLabel .
+    FILTER(LANG(?prefLabel) = "nl" )
+
     OPTIONAL {
         ?uri skos:altLabel ?altLabel .
         FILTER(LANG(?altLabel) = "nl")
@@ -62,20 +35,6 @@ WHERE {
         ?uri skos:scopeNote ?scopeNote .
         FILTER(LANG(?scopeNote) = "nl")
     }
-    OPTIONAL {
-        ?uri skos:broader ?broader_uri .
-        ?broader_uri skos:prefLabel ?broader_prefLabel .
-        FILTER(LANG(?broader_prefLabel) = "nl")
-    }
-    OPTIONAL {
-        ?uri skos:narrower ?narrower_uri .
-        ?narrower_uri skos:prefLabel ?narrower_prefLabel .
-        FILTER(LANG(?narrower_prefLabel) = "nl")
-    }
-    OPTIONAL {
-        ?uri skos:related ?related_uri .
-        ?related_uri skos:prefLabel ?related_prefLabel .
-        FILTER(LANG(?related_prefLabel) = "nl")
-    }
 }
-LIMIT 10 
+LIMIT 50
+


### PR DESCRIPTION
Query for the GTAA persoonsnamen can take quite a while because of the size of the term source (>200k). Therefore, the query was defined so that it would only allow single word source. Also, the number of result concepts was limited to 10. So I thought. It turned out the limit was on triples, because of the CONSTRUCT query type. Now the limit is raised to 50, so that it will return some 10 concepts when found. Still, whenever a term is searched that is very unique and 50 triples aren't produced, the whole dataset is being searched and timeouts can happen. 