### PR TITLE
build: Revert multi-arch Docker images

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,6 @@ jobs:
         uses: docker/build-push-action@v2.9.0
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
           push: true
           build-args: PACKAGE_DIR=packages/${{ steps.vars.outputs.package_name }}
           tags: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,11 +31,6 @@ jobs:
           echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
           echo "::set-output name=docker_image::ghcr.io/netwerk-digitaal-erfgoed/${{steps.parse-tag.outputs.group1}}"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1.2.0
-        with:
-          platforms: arm64
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1.6.0
         with:


### PR DESCRIPTION
* GitHub Actions does not support arch64 natively yet 
  (https://github.com/actions/virtual-environments/issues/2187), so we need QEMU.
* QEMU slows down our builds too much: from ~2 min to ~11 min.
* Revert "feat: Build multi-arch Docker image (#568)"
* Revert "build: Enable QEMU support for multi-arch builds"
