### PR TITLE
fix: Calculate score per individual term

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,9 +15,9 @@ export default {
   ],
   coverageThreshold: {
     global: {
-      lines: 88.96,
-      statements: 88.83,
-      branches: 92.15,
+      lines: 88.94,
+      statements: 88.81,
+      branches: 92.1,
       functions: 86.9,
     },
   },

--- a/packages/network-of-terms-query/test/fixtures/terms.ttl
+++ b/packages/network-of-terms-query/test/fixtures/terms.ttl
@@ -16,7 +16,9 @@
 
 <https://example.com/resources/painting>
     a <http://www.w3.org/2008/05/skos#Concept> ;
-    skos:altLabel "painted things that can be beautiful" ;
+    skos:altLabel
+        "painted things that can be beautiful",
+        "another altLabel" ;
     skos:related <https://example.com/resources/art> ;
     skos:broader <https://example.com/resources/art> .
 

--- a/packages/network-of-terms-reconciliation/src/score.ts
+++ b/packages/network-of-terms-reconciliation/src/score.ts
@@ -8,27 +8,23 @@ import RDF from 'rdf-js';
  */
 export const score = (searchString: string, term: Term): number => {
   // Score both prefLabels and altLabels and return the highest score.
-  return Math.max(
-    calculateMatchingScore(searchString.toLowerCase(), term.prefLabels),
-    calculateMatchingScore(searchString.toLowerCase(), term.altLabels)
-  );
+  return calculateMatchingScore(searchString.toLowerCase(), [
+    ...term.prefLabels,
+    ...term.altLabels,
+  ]);
 };
 
 const calculateMatchingScore = (
   searchString: string,
   literals: RDF.Literal[]
 ): number => {
-  if (literals.length === 0) {
-    return 0;
-  }
-
-  const distance = literals.reduce(
-    (distance, literal) =>
-      distance -
+  const scores = literals.map(
+    literal =>
+      1 -
       leven(searchString.toLowerCase(), literal.value.toLowerCase()) /
-        Math.max(searchString.length, literal.value.length),
-    1
+        Math.max(searchString.length, literal.value.length)
   );
+  const maxScore = Math.max(...scores);
 
-  return Math.round((distance + Number.EPSILON) * 10000) / 100; // Return percentage match rounded to two decimals.
+  return Math.round((maxScore + Number.EPSILON) * 10000) / 100; // Return percentage match rounded to two decimals.
 };

--- a/packages/network-of-terms-reconciliation/test/server.test.ts
+++ b/packages/network-of-terms-reconciliation/test/server.test.ts
@@ -62,7 +62,7 @@ describe('Server', () => {
     expect(results.q2.result[0].name).toEqual('All things art');
     expect(results.q2.result[0].score).toEqual(42.86); // Match of ‘things’ in prefLabel ‘All things art’.
     expect(results.q2.result[1].description).toEqual(
-      'painted things that can be beautiful'
+      'painted things that can be beautiful • another altLabel'
     ); // Result has no prefLabel.
     expect(results.q2.result[1].score).toEqual(16.67); // Match of ‘things’ in altLabel ‘painted things that can be beautiful’.
 


### PR DESCRIPTION
Previously, we calculated a combined score per set of prefLabels and set
of altLabels and took the max between the two.

Change this to calculate score for each of the individual prefLabels and
altLabels.
