### PR TITLE
feat: Improve reconciliation scoring

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,10 +15,10 @@ export default {
   ],
   coverageThreshold: {
     global: {
-      lines: 88.94,
-      statements: 88.81,
+      lines: 89.02,
+      statements: 88.91,
       branches: 92.1,
-      functions: 86.9,
+      functions: 87.05,
     },
   },
   transform: {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -20332,6 +20332,11 @@
         "node": ">=0.6.19"
       }
     },
+    "node_modules/string-comparison": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/string-comparison/-/string-comparison-1.1.0.tgz",
+      "integrity": "sha512-9its9Hn37UNw6HlHFH0CGaTkkCWSCFtI3J5qLbuJqKAfbgEc0Ix+rFWfky47TcLlr5GvTSAqbGzHzQndZ7QaSQ=="
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "dev": true,
@@ -22036,8 +22041,8 @@
         "fastify-accepts": "^2.2.0",
         "fastify-cors": "^6.0.3",
         "fastify-formbody": "^5.2.0",
-        "leven": "^4.0.0",
-        "rdf-js": "^4.0.2"
+        "rdf-js": "^4.0.2",
+        "string-comparison": "^1.1.0"
       },
       "devDependencies": {
         "@types/accepts": "^1.3.5",
@@ -22045,17 +22050,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "packages/network-of-terms-reconciliation/node_modules/leven": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-4.0.0.tgz",
-      "integrity": "sha512-puehA3YKku3osqPlNuzGDUHq8WpwXupUg1V6NXdV38G+gr+gkBwFC8g1b/+YcIvp8gnqVIus+eJCH/eGsRmJNw==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   },
@@ -29559,15 +29553,8 @@
         "fastify-cors": "^6.0.3",
         "fastify-formbody": "^5.2.0",
         "jest-dev-server": "^6.0.3",
-        "leven": "^4.0.0",
-        "rdf-js": "^4.0.2"
-      },
-      "dependencies": {
-        "leven": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/leven/-/leven-4.0.0.tgz",
-          "integrity": "sha512-puehA3YKku3osqPlNuzGDUHq8WpwXupUg1V6NXdV38G+gr+gkBwFC8g1b/+YcIvp8gnqVIus+eJCH/eGsRmJNw=="
-        }
+        "rdf-js": "^4.0.2",
+        "string-comparison": "^1.1.0"
       }
     },
     "@nodelib/fs.scandir": {
@@ -38406,6 +38393,11 @@
     "string-argv": {
       "version": "0.1.2",
       "dev": true
+    },
+    "string-comparison": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/string-comparison/-/string-comparison-1.1.0.tgz",
+      "integrity": "sha512-9its9Hn37UNw6HlHFH0CGaTkkCWSCFtI3J5qLbuJqKAfbgEc0Ix+rFWfky47TcLlr5GvTSAqbGzHzQndZ7QaSQ=="
     },
     "string-length": {
       "version": "4.0.2",

--- a/packages/network-of-terms-reconciliation/package.json
+++ b/packages/network-of-terms-reconciliation/package.json
@@ -13,8 +13,8 @@
     "fastify-accepts": "^2.2.0",
     "fastify-cors": "^6.0.3",
     "fastify-formbody": "^5.2.0",
-    "leven": "^4.0.0",
-    "rdf-js": "^4.0.2"
+    "rdf-js": "^4.0.2",
+    "string-comparison": "^1.1.0"
   },
   "devDependencies": {
     "@types/accepts": "^1.3.5",

--- a/packages/network-of-terms-reconciliation/test/score.test.ts
+++ b/packages/network-of-terms-reconciliation/test/score.test.ts
@@ -1,0 +1,9 @@
+import {calculateMatchingScore} from '../src/score';
+
+describe('Score', () => {
+  it('ignores punctuation', () => {
+    expect(
+      calculateMatchingScore('pieter de hooch', ['Hooch, Pieter de'])
+    ).toEqual(100);
+  });
+});

--- a/packages/network-of-terms-reconciliation/test/server.test.ts
+++ b/packages/network-of-terms-reconciliation/test/server.test.ts
@@ -60,11 +60,11 @@ describe('Server', () => {
     // Results must be sorted by score in decreasing order.
     expect(results.q2.result).toHaveLength(2);
     expect(results.q2.result[0].name).toEqual('All things art');
-    expect(results.q2.result[0].score).toEqual(42.86); // Match of ‘things’ in prefLabel ‘All things art’.
+    expect(results.q2.result[0].score).toEqual(81.65); // Match of ‘things’ in prefLabel ‘All things art’.
     expect(results.q2.result[1].description).toEqual(
       'painted things that can be beautiful • another altLabel'
     ); // Result has no prefLabel.
-    expect(results.q2.result[1].score).toEqual(16.67); // Match of ‘things’ in altLabel ‘painted things that can be beautiful’.
+    expect(results.q2.result[1].score).toEqual(63.25); // Match of ‘things’ in altLabel ‘painted things that can be beautiful’.
 
     expect(results.q3.result).toEqual([]); // No results.
   });


### PR DESCRIPTION
* Use cosine similarity instead of Levenshtein to ignore differences in
  word order.
* Ignore punctuation marks.

Fix #580.
