### PR TITLE
feat: Return feature URL from catalog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2846,15 +2846,20 @@
       }
     },
     "node_modules/@comunica/bindings-factory": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bindings-factory/-/bindings-factory-2.0.1.tgz",
-      "integrity": "sha512-EbtDiHVt9tzr57jGq64/hH2UrCZBB6Vikn2S76FZtEbYecoN+pm+rymKGGuHNgthXQs+zNtInPVk69VZMQKMwA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bindings-factory/-/bindings-factory-2.2.0.tgz",
+      "integrity": "sha512-KFn/djqJwTn1nQLI/T/roOf2A+otuNtPmMtXba0rna+X59sjbA7e4KUnG4wMd9yKQVt2/1a1e9F3vVvGOMB63A==",
       "dependencies": {
         "@rdfjs/types": "*",
-        "immutable": "^3.8.2",
+        "immutable": "^4.0.0",
         "rdf-data-factory": "^1.1.0",
         "rdf-string": "^1.6.0"
       }
+    },
+    "node_modules/@comunica/bindings-factory/node_modules/immutable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
+      "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw=="
     },
     "node_modules/@comunica/bus-dereference": {
       "version": "2.0.2",
@@ -21646,6 +21651,7 @@
       "version": "0.0.0-semantically-released",
       "license": "EUPL-1.2",
       "dependencies": {
+        "@comunica/bindings-factory": "^2.2.0",
         "@comunica/query-sparql-rdfjs": "^2.0.6",
         "@netwerk-digitaal-erfgoed/network-of-terms-query": "*",
         "globby": "^13.1.1",
@@ -24567,14 +24573,21 @@
       }
     },
     "@comunica/bindings-factory": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bindings-factory/-/bindings-factory-2.0.1.tgz",
-      "integrity": "sha512-EbtDiHVt9tzr57jGq64/hH2UrCZBB6Vikn2S76FZtEbYecoN+pm+rymKGGuHNgthXQs+zNtInPVk69VZMQKMwA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bindings-factory/-/bindings-factory-2.2.0.tgz",
+      "integrity": "sha512-KFn/djqJwTn1nQLI/T/roOf2A+otuNtPmMtXba0rna+X59sjbA7e4KUnG4wMd9yKQVt2/1a1e9F3vVvGOMB63A==",
       "requires": {
         "@rdfjs/types": "*",
-        "immutable": "^3.8.2",
+        "immutable": "^4.0.0",
         "rdf-data-factory": "^1.1.0",
         "rdf-string": "^1.6.0"
+      },
+      "dependencies": {
+        "immutable": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
+          "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw=="
+        }
       }
     },
     "@comunica/bus-dereference": {
@@ -29195,6 +29208,7 @@
     "@netwerk-digitaal-erfgoed/network-of-terms-catalog": {
       "version": "file:packages/network-of-terms-catalog",
       "requires": {
+        "@comunica/bindings-factory": "*",
         "@comunica/core": "^2.0.1",
         "@comunica/query-sparql-rdfjs": "^2.0.6",
         "@comunica/types": "^2.0.1",

--- a/packages/network-of-terms-catalog/catalog/datasets/abr.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/abr.jsonld
@@ -44,7 +44,8 @@
             "actionApplication": {
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
-            }
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/adamlink-straten.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/adamlink-straten.jsonld
@@ -38,7 +38,8 @@
             "actionApplication": {
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
-            }
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/brinkman.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/brinkman.jsonld
@@ -44,7 +44,8 @@
             "actionApplication": {
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
-            }
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/cht.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/cht.jsonld
@@ -44,7 +44,8 @@
             "actionApplication": {
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
-            }
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/eurovoc.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/eurovoc.jsonld
@@ -38,7 +38,8 @@
             "actionApplication": {
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
-            }
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/gtaa-classificatie.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/gtaa-classificatie.jsonld
@@ -38,7 +38,8 @@
             "actionApplication": {
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
-            }
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/gtaa-genres.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/gtaa-genres.jsonld
@@ -38,7 +38,8 @@
             "actionApplication": {
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
-            }
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/gtaa-geografische-namen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/gtaa-geografische-namen.jsonld
@@ -38,7 +38,8 @@
             "actionApplication": {
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
-            }
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/gtaa-namen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/gtaa-namen.jsonld
@@ -38,7 +38,8 @@
             "actionApplication": {
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
-            }
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/gtaa-onderwerpen-beng.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/gtaa-onderwerpen-beng.jsonld
@@ -38,7 +38,8 @@
             "actionApplication": {
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
-            }
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/gtaa-onderwerpen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/gtaa-onderwerpen.jsonld
@@ -38,7 +38,8 @@
             "actionApplication": {
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
-            }
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/gtaa-persoonsnamen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/gtaa-persoonsnamen.jsonld
@@ -38,7 +38,8 @@
             "actionApplication": {
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
-            }
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/muziekschatten-onderwerpen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/muziekschatten-onderwerpen.jsonld
@@ -38,7 +38,8 @@
             "actionApplication": {
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
-            }
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/muziekschatten-personen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/muziekschatten-personen.jsonld
@@ -38,7 +38,8 @@
             "actionApplication": {
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
-            }
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/mw-genresstijlen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/mw-genresstijlen.jsonld
@@ -38,7 +38,8 @@
             "actionApplication": {
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
-            }
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/mw-personengroepen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/mw-personengroepen.jsonld
@@ -38,7 +38,8 @@
             "actionApplication": {
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
-            }
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/nmvw.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/nmvw.jsonld
@@ -38,7 +38,8 @@
             "actionApplication": {
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
-            }
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/nta.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/nta.jsonld
@@ -44,7 +44,8 @@
             "actionApplication": {
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
-            }
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/rkdartists.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/rkdartists.jsonld
@@ -38,7 +38,8 @@
             "actionApplication": {
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
-            }
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/stcn-drukkers.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/stcn-drukkers.jsonld
@@ -38,7 +38,8 @@
             "actionApplication": {
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
-            }
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/wo2thesaurus.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/wo2thesaurus.jsonld
@@ -38,7 +38,8 @@
             "actionApplication": {
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
-            }
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/package.json
+++ b/packages/network-of-terms-catalog/package.json
@@ -43,6 +43,7 @@
   },
   "homepage": "https://github.com/netwerk-digitaal-erfgoed/network-of-terms-catalog#readme",
   "dependencies": {
+    "@comunica/bindings-factory": "^2.2.0",
     "@comunica/query-sparql-rdfjs": "^2.0.6",
     "@netwerk-digitaal-erfgoed/network-of-terms-query": "*",
     "globby": "^13.1.1",

--- a/packages/network-of-terms-catalog/shacl/dataset.jsonld
+++ b/packages/network-of-terms-catalog/shacl/dataset.jsonld
@@ -98,6 +98,17 @@
           },
           "sh:qualifiedMinCount": 1,
           "sh:qualifiedMaxCount": 1
+        },
+        {
+          "sh:path": {
+            "@id": "schema:potentialAction"
+          },
+          "sh:qualifiedValueShape": {
+            "sh:class": {
+              "@id": "schema:Action"
+            }
+          },
+          "sh:qualifiedMinCount": 0
         }
       ]
     },
@@ -146,6 +157,49 @@
         {
           "sh:path": {
             "@id": "schema:query"
+          },
+          "sh:minCount": 1,
+          "sh:maxCount": 1
+        }
+      ]
+    },
+    {
+      "@type": "sh:NodeShape",
+      "sh:targetClass": {
+        "@id": "schema:Action"
+      },
+      "sh:property": [
+        {
+          "sh:path": {
+            "@id": "schema:target"
+          },
+          "sh:class": {
+            "@id": "schema:EntryPoint"
+          },
+          "sh:minCount": 1,
+          "sh:maxCount": 1
+        }
+      ]
+    },
+    {
+      "@type": "sh:NodeShape",
+      "sh:targetClass": {
+        "@id": "schema:EntryPoint"
+      },
+      "sh:property": [
+        {
+          "sh:path": {
+            "@id": "schema:actionApplication"
+          },
+          "sh:class": {
+            "@id": "schema:SoftwareApplication"
+          },
+          "sh:minCount": 1,
+          "sh:maxCount": 1
+        },
+        {
+          "sh:path": {
+            "@id": "schema:urlTemplate"
           },
           "sh:minCount": 1,
           "sh:maxCount": 1


### PR DESCRIPTION
BREAKING CHANGE: `dataset.distribution.features` is now a list of
`Feature`s that contain both the type and the URL at which the feature
is available.
