### PR TITLE
fix: Return correct source when sources share URI prefix

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,10 +15,10 @@ export default {
   ],
   coverageThreshold: {
     global: {
-      lines: 89.12,
-      statements: 89.06,
-      branches: 91.35,
-      functions: 87.2,
+      lines: 89.49,
+      statements: 89.42,
+      branches: 91.17,
+      functions: 87.35,
     },
   },
   transform: {},

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/brinkman-nta-stcn.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/brinkman-nta-stcn.rq
@@ -1,6 +1,7 @@
 PREFIX schema: <http://schema.org/>
 # Do not remove this prefix - KB data uses old version of SKOS
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX void: <http://rdfs.org/ns/void#>
 
 CONSTRUCT {
     ?uri a skos:Concept ;
@@ -14,7 +15,8 @@ CONSTRUCT {
         skos:scopeNote ?schema_description ;
         skos:broader ?broader_uri ;
         skos:narrower ?narrower_uri ;
-        skos:related ?related_uri .
+        skos:related ?related_uri ;
+        skos:inScheme ?datasetUri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
     ?related_uri skos:prefLabel ?related_prefLabel .
@@ -28,6 +30,10 @@ WHERE {
 
     ?uri a ?type .
     VALUES ?type { skos:Concept schema:Person schema:Organization } .
+
+    ?uri schema:mainEntityOfPage/schema:isPartOf | foaf:isPrimaryTopicOf/void:inDataset ?datasetUriRaw .
+    # In the future, KB will split off the STCN printers dataset from the main STCN dataset. In the meantime, we have to translate the latter into the former.
+    BIND(IF(?datasetUriRaw = <http://data.bibliotheken.nl/id/dataset/stcn>, <http://data.bibliotheken.nl/id/dataset/stcn/printers>, ?datasetUriRaw) as ?datasetUri) .
 
     # For Brinkman
     OPTIONAL {

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/gtaa.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/gtaa.rq
@@ -8,7 +8,8 @@ CONSTRUCT {
         skos:scopeNote ?scopeNote ;
         skos:broader ?broader_uri ;
         skos:narrower ?narrower_uri ;
-        skos:related ?related_uri .
+        skos:related ?related_uri ;
+        skos:inScheme ?datasetUri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
     ?related_uri skos:prefLabel ?related_prefLabel .
@@ -17,7 +18,8 @@ WHERE {
 
     VALUES ?uri { ?uris }
 
-    ?uri a skos:Concept .
+    ?uri a skos:Concept ;
+        skos:inScheme ?datasetUri .
 
     OPTIONAL {
         ?uri skos:prefLabel ?prefLabel .

--- a/packages/network-of-terms-query/src/catalog.ts
+++ b/packages/network-of-terms-query/src/catalog.ts
@@ -3,6 +3,12 @@ import {URL} from 'url';
 export class Catalog {
   constructor(readonly datasets: ReadonlyArray<Dataset>) {}
 
+  public getDatasetByIri(iri: IRI): Dataset | undefined {
+    return this.datasets.find(
+      dataset => dataset.iri.toString() === iri.toString()
+    );
+  }
+
   public getDatasetByDistributionIri(iri: IRI): Dataset | undefined {
     return this.datasets.find(
       dataset => dataset.getDistributionByIri(iri) !== undefined

--- a/packages/network-of-terms-query/src/server-test.ts
+++ b/packages/network-of-terms-query/src/server-test.ts
@@ -47,7 +47,8 @@ export const testCatalog = (port: number) =>
             ?s ?p ?o ;
               skos:broader ?broader_uri ;
               skos:narrower ?narrower_uri ;
-              skos:related ?related_uri .
+              skos:related ?related_uri ;
+              skos:inScheme <https://data.rkd.nl/rkdartists> .
             ?broader_uri skos:prefLabel ?broader_prefLabel .
             ?narrower_uri skos:prefLabel ?narrower_prefLabel .
             ?related_uri skos:prefLabel ?related_prefLabel .

--- a/packages/network-of-terms-query/src/terms.ts
+++ b/packages/network-of-terms-query/src/terms.ts
@@ -11,7 +11,8 @@ export class Term {
     readonly seeAlso: RDF.NamedNode[],
     readonly broaderTerms: RelatedTerm[],
     readonly narrowerTerms: RelatedTerm[],
-    readonly relatedTerms: RelatedTerm[]
+    readonly relatedTerms: RelatedTerm[],
+    readonly datasetIri: RDF.Term | undefined
   ) {}
 }
 
@@ -30,6 +31,7 @@ class SparqlResultTerm {
   broaderTerms: RDF.Term[] = [];
   narrowerTerms: RDF.Term[] = [];
   relatedTerms: RDF.Term[] = [];
+  inScheme: RDF.Term | undefined = undefined;
 }
 
 export class TermsTransformer {
@@ -52,6 +54,7 @@ export class TermsTransformer {
     ['http://www.w3.org/2008/05/skos#narrower', 'narrowerTerms'],
     ['http://www.w3.org/2004/02/skos/core#related', 'relatedTerms'],
     ['http://www.w3.org/2008/05/skos#related', 'relatedTerms'],
+    ['http://www.w3.org/2004/02/skos/core#inScheme', 'inScheme'],
   ]);
 
   fromQuad(quad: RDF.Quad): void {
@@ -99,7 +102,8 @@ export class TermsTransformer {
         this.mapRelatedTerms(term.narrowerTerms).sort(
           alphabeticallyByPrefLabel
         ),
-        this.mapRelatedTerms(term.relatedTerms).sort(alphabeticallyByPrefLabel)
+        this.mapRelatedTerms(term.relatedTerms).sort(alphabeticallyByPrefLabel),
+        term.inScheme
       );
     });
   }


### PR DESCRIPTION
* Queries can return a `skos:inScheme` triple that will be used
  instead of the dataset matching the URI prefix.

Fix #492.
Fix #604.
