### PR TITLE
feat: Add source ‘Brabantse gebouwen’

### DIFF
--- a/packages/network-of-terms-catalog/catalog/datasets/brabantse-gebouwen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/brabantse-gebouwen.jsonld
@@ -1,0 +1,48 @@
+{
+  "@context": "https://schema.org/docs/jsonldcontext.jsonld",
+  "@id": "https://data.brabantcloud.nl/gebouwen",
+  "@type": "Dataset",
+  "name": [
+    {
+      "@language": "nl",
+      "@value": "Brabantse gebouwen"
+    }
+  ],
+  "creator": [
+    {
+      "@id": "https://www.erfgoedbrabant.nl"
+    }
+  ],
+  "url": [
+    "https://data.brabantcloud.nl/id/ark:15052/"
+  ],
+  "distribution": [
+    {
+      "@id": "https://data.brabantcloud.nl/gebouwen/query/",
+      "@type": "DataDownload",
+      "contentUrl": "https://data.brabantcloud.nl/gebouwen/query/",
+      "encodingFormat": "application/sparql-query",
+      "potentialAction": [
+        {
+          "@type": "SearchAction",
+          "query": "file://catalog/queries/search/brabantse-gebouwen.rq"
+        },
+        {
+          "@type": "FindAction",
+          "query": "file://catalog/queries/lookup/brabantse-gebouwen.rq"
+        },
+        {
+          "@type": "Action",
+          "target": {
+            "@type": "EntryPoint",
+            "actionApplication": {
+              "@id": "https://reconciliation-api.github.io/specs/latest/",
+              "@type": "SoftwareApplication"
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/network-of-terms-catalog/catalog/publishers.jsonld
+++ b/packages/network-of-terms-catalog/catalog/publishers.jsonld
@@ -72,6 +72,12 @@
       "@type": "Organization",
       "name": "Stichting AdamNet",
       "alternateName": "AdamNet"
+    },
+    {
+      "@id": "https://www.erfgoedbrabant.nl",
+      "@type": "Organization",
+      "name": "Erfgoed Brabant",
+      "alternateName": "Erfgoed Brabant"
     }
   ]
 }

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/brabantse-gebouwen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/brabantse-gebouwen.rq
@@ -22,8 +22,8 @@ WHERE {
     OPTIONAL {
         ?uri schema:additionalType <http://vocab.getty.edu/aat/300000641> .
         BIND("Type: kloostergebouw" AS ?buildingTypeScopeNote)
-      }
-      OPTIONAL {
+    }
+    OPTIONAL {
         ?uri schema:address ?address .
         OPTIONAL { ?address schema:streetAddress ?streetAddress }
         OPTIONAL { ?address schema:addressLocality ?addressLocality }

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/brabantse-gebouwen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/brabantse-gebouwen.rq
@@ -5,7 +5,7 @@ CONSTRUCT {
     ?uri a skos:Concept ;
         skos:prefLabel ?schema_name ;
         skos:altLabel ?schema_alternateName ;
-		    skos:scopeNote ?schema_description,
+        skos:scopeNote ?schema_description,
                        ?buildingTypeScopeNote,
                        ?addressScopeNote .
 }
@@ -20,14 +20,14 @@ WHERE {
     OPTIONAL { ?uri schema:alternateName ?schema_alternateName }
     OPTIONAL { ?uri schema:description ?schema_description }
     OPTIONAL {
-    	?uri schema:additionalType <http://vocab.getty.edu/aat/300000641> .
-	    BIND("Type: kloostergebouw" AS ?buildingTypeScopeNote)
-  	}
-	  OPTIONAL {
+        ?uri schema:additionalType <http://vocab.getty.edu/aat/300000641> .
+        BIND("Type: kloostergebouw" AS ?buildingTypeScopeNote)
+      }
+      OPTIONAL {
         ?uri schema:address ?address .
-		    OPTIONAL { ?address schema:streetAddress ?streetAddress }
-  	    OPTIONAL { ?address schema:addressLocality ?addressLocality }
-		    OPTIONAL { ?address schema:addressRegion ?addressRegion }
+        OPTIONAL { ?address schema:streetAddress ?streetAddress }
+        OPTIONAL { ?address schema:addressLocality ?addressLocality }
+        OPTIONAL { ?address schema:addressRegion ?addressRegion }
         BIND(
             COALESCE(
                 IF(?streetAddress && ?addressLocality && ?addressRegion, CONCAT("Adres: ", ?streetAddress, ", ", ?addressLocality, ", ", ?addressRegion), ?noAddress),

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/brabantse-gebouwen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/brabantse-gebouwen.rq
@@ -1,0 +1,40 @@
+PREFIX schema: <https://schema.org/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+CONSTRUCT {
+    ?uri a skos:Concept ;
+        skos:prefLabel ?schema_name ;
+        skos:altLabel ?schema_alternateName ;
+		    skos:scopeNote ?schema_description,
+                       ?buildingTypeScopeNote,
+                       ?addressScopeNote .
+}
+WHERE {
+    # For example:
+    # Huize Boschlust: <https://data.brabantcloud.nl/id/ark:15052/62dd4e81-b7d6-4fc2-9473-5f4b17226105>
+    # Mariaklooster: <https://data.brabantcloud.nl/id/ark:15052/0963f6bb-4b84-4e37-a087-31bbabfda4bb>
+    VALUES ?uri { ?uris }
+
+    ?uri a schema:LandmarksOrHistoricalBuildings .
+    OPTIONAL { ?uri schema:name ?schema_name }
+    OPTIONAL { ?uri schema:alternateName ?schema_alternateName }
+    OPTIONAL { ?uri schema:description ?schema_description }
+    OPTIONAL {
+    	?uri schema:additionalType <http://vocab.getty.edu/aat/300000641> .
+	    BIND("Type: kloostergebouw" AS ?buildingTypeScopeNote)
+  	}
+	  OPTIONAL {
+        ?uri schema:address ?address .
+		    OPTIONAL { ?address schema:streetAddress ?streetAddress }
+  	    OPTIONAL { ?address schema:addressLocality ?addressLocality }
+		    OPTIONAL { ?address schema:addressRegion ?addressRegion }
+        BIND(
+            COALESCE(
+                IF(?streetAddress && ?addressLocality && ?addressRegion, CONCAT("Adres: ", ?streetAddress, ", ", ?addressLocality, ", ", ?addressRegion), ?noAddress),
+                IF(?streetAddress && ?addressLocality, CONCAT("Adres: ", ?streetAddress, ", ", ?addressLocality), ?noAddress),
+                IF(?streetAddress, CONCAT("Adres: ", ?streetAddress), ?noAddress)
+            ) AS ?addressScopeNote
+        )
+    }
+}
+LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/brabantse-gebouwen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/brabantse-gebouwen.rq
@@ -20,8 +20,8 @@ WHERE {
     OPTIONAL {
         ?uri schema:additionalType <http://vocab.getty.edu/aat/300000641> .
         BIND("Type: kloostergebouw" AS ?buildingTypeScopeNote)
-      }
-      OPTIONAL {
+    }
+    OPTIONAL {
         ?uri schema:address ?address .
         OPTIONAL { ?address schema:streetAddress ?streetAddress }
         OPTIONAL { ?address schema:addressLocality ?addressLocality }

--- a/packages/network-of-terms-catalog/catalog/queries/search/brabantse-gebouwen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/brabantse-gebouwen.rq
@@ -1,0 +1,38 @@
+PREFIX schema: <https://schema.org/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+CONSTRUCT {
+    ?uri a skos:Concept ;
+        skos:prefLabel ?schema_name ;
+        skos:altLabel ?schema_alternateName ;
+		    skos:scopeNote ?schema_description,
+                       ?buildingTypeScopeNote,
+                       ?addressScopeNote .
+}
+WHERE {
+    ?uri a schema:LandmarksOrHistoricalBuildings .
+    ?uri ?predicate ?label .
+    VALUES ?predicate { schema:name schema:alternateName }
+    FILTER(CONTAINS(LCASE(?label), LCASE(?query)))
+    OPTIONAL { ?uri schema:name ?schema_name }
+    OPTIONAL { ?uri schema:alternateName ?schema_alternateName }
+    OPTIONAL { ?uri schema:description ?schema_description }
+    OPTIONAL {
+    	?uri schema:additionalType <http://vocab.getty.edu/aat/300000641> .
+	    BIND("Type: kloostergebouw" AS ?buildingTypeScopeNote)
+  	}
+	  OPTIONAL {
+        ?uri schema:address ?address .
+		    OPTIONAL { ?address schema:streetAddress ?streetAddress }
+  	    OPTIONAL { ?address schema:addressLocality ?addressLocality }
+		    OPTIONAL { ?address schema:addressRegion ?addressRegion }
+        BIND(
+            COALESCE(
+                IF(?streetAddress && ?addressLocality && ?addressRegion, CONCAT("Adres: ", ?streetAddress, ", ", ?addressLocality, ", ", ?addressRegion), ?noAddress),
+                IF(?streetAddress && ?addressLocality, CONCAT("Adres: ", ?streetAddress, ", ", ?addressLocality), ?noAddress),
+                IF(?streetAddress, CONCAT("Adres: ", ?streetAddress), ?noAddress)
+            ) AS ?addressScopeNote
+        )
+    }
+}
+LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/brabantse-gebouwen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/brabantse-gebouwen.rq
@@ -5,7 +5,7 @@ CONSTRUCT {
     ?uri a skos:Concept ;
         skos:prefLabel ?schema_name ;
         skos:altLabel ?schema_alternateName ;
-		    skos:scopeNote ?schema_description,
+        skos:scopeNote ?schema_description,
                        ?buildingTypeScopeNote,
                        ?addressScopeNote .
 }
@@ -18,14 +18,14 @@ WHERE {
     OPTIONAL { ?uri schema:alternateName ?schema_alternateName }
     OPTIONAL { ?uri schema:description ?schema_description }
     OPTIONAL {
-    	?uri schema:additionalType <http://vocab.getty.edu/aat/300000641> .
-	    BIND("Type: kloostergebouw" AS ?buildingTypeScopeNote)
-  	}
-	  OPTIONAL {
+        ?uri schema:additionalType <http://vocab.getty.edu/aat/300000641> .
+        BIND("Type: kloostergebouw" AS ?buildingTypeScopeNote)
+      }
+      OPTIONAL {
         ?uri schema:address ?address .
-		    OPTIONAL { ?address schema:streetAddress ?streetAddress }
-  	    OPTIONAL { ?address schema:addressLocality ?addressLocality }
-		    OPTIONAL { ?address schema:addressRegion ?addressRegion }
+        OPTIONAL { ?address schema:streetAddress ?streetAddress }
+        OPTIONAL { ?address schema:addressLocality ?addressLocality }
+        OPTIONAL { ?address schema:addressRegion ?addressRegion }
         BIND(
             COALESCE(
                 IF(?streetAddress && ?addressLocality && ?addressRegion, CONCAT("Adres: ", ?streetAddress, ", ", ?addressLocality, ", ", ?addressRegion), ?noAddress),


### PR DESCRIPTION
This PR proposes a new terminology source: 'Brabantse gebouwen' from Erfgoed Brabant. The source currently only contains monasteries; types such as churches and chapels are going to be added in the near future.