### PR TITLE
fix: Blank names returned from Muziekschatten

### DIFF
--- a/packages/network-of-terms-catalog/catalog/queries/lookup/muziekschatten.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/muziekschatten.rq
@@ -60,7 +60,7 @@ WHERE {
         OPTIONAL { ?uri schema:givenName ?schema_givenName }
         BIND(
             COALESCE(
-                IF(BOUND(?schema_familyName) && BOUND(?schema_givenName), CONCAT(?schema_familyName, ", ", ?schema_givenName), ?noName),
+                IF(STRLEN(?schema_familyName) > 0 && STRLEN(?schema_givenName) > 0, CONCAT(?schema_familyName, ", ", ?schema_givenName), ?noName),
                 ?schema_familyName,
                 ?schema_givenName,
                 ?schema_name # Fallback

--- a/packages/network-of-terms-catalog/catalog/queries/search/muziekschatten-personen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/muziekschatten-personen.rq
@@ -54,7 +54,7 @@ WHERE {
     OPTIONAL { ?uri schema:givenName ?schema_givenName }
     BIND(
         COALESCE(
-            IF(BOUND(?schema_familyName) && BOUND(?schema_givenName), CONCAT(?schema_familyName, ", ", ?schema_givenName), ?noName),
+            IF(STRLEN(?schema_familyName) > 0 && STRLEN(?schema_givenName) > 0, CONCAT(?schema_familyName, ", ", ?schema_givenName), ?noName),
             ?schema_familyName,
             ?schema_givenName,
             ?schema_name # Fallback


### PR DESCRIPTION
Apparently STRLEN() rather than BOUND() is needed here.
