### PR TITLE
fix: STCN

### DIFF
--- a/packages/network-of-terms-catalog/catalog/queries/lookup/brinkman-nta-stcn.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/brinkman-nta-stcn.rq
@@ -31,9 +31,7 @@ WHERE {
     ?uri a ?type .
     VALUES ?type { skos:Concept schema:Person schema:Organization } .
 
-    ?uri schema:mainEntityOfPage/schema:isPartOf | foaf:isPrimaryTopicOf/void:inDataset ?datasetUriRaw .
-    # In the future, KB will split off the STCN printers dataset from the main STCN dataset. In the meantime, we have to translate the latter into the former.
-    BIND(IF(?datasetUriRaw = <http://data.bibliotheken.nl/id/dataset/stcn>, <http://data.bibliotheken.nl/id/dataset/stcn/printers>, ?datasetUriRaw) as ?datasetUri) .
+    ?uri schema:mainEntityOfPage/schema:isPartOf | foaf:isPrimaryTopicOf/void:inDataset ?datasetUri .
 
     # For Brinkman
     OPTIONAL {
@@ -76,6 +74,11 @@ WHERE {
         OPTIONAL { ?uri schema:name ?schema_name }
         OPTIONAL { ?uri schema:alternateName ?schema_alternateName }
         OPTIONAL { ?uri schema:description ?schema_description }
+    }
+
+    # For STCN
+    OPTIONAL {
+        ?uri schema:location/schema:address/schema:addressLocality ?scopeNote
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/stcn-drukkers.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/stcn-drukkers.rq
@@ -25,9 +25,8 @@ WHERE {
     # http://data.bibliotheken.nl/id/thes/p338012834 for Plantijn working in Antwerp
     # The original source (STCN) shows also a time period, this data currently not available in the LOD version.
     OPTIONAL { 
-     ?uri schema:location/schema:address/schema:addressLocality ?place 
+     ?uri schema:location/schema:address/schema:addressLocality ?scopeNote 
     }
-    BIND(COALESCE(IF(BOUND(?place), ?place, ?noPlace)) as ?scopeNote)
     OPTIONAL { ?uri schema:name ?schema_name }
     OPTIONAL { ?uri schema:alternateName ?schema_alternateName }
 }

--- a/packages/network-of-terms-catalog/catalog/queries/search/stcn-drukkers.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/stcn-drukkers.rq
@@ -1,3 +1,5 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX schema: <http://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX void: <http://rdfs.org/ns/void#>
 
@@ -6,7 +8,7 @@ CONSTRUCT {
         skos:prefLabel ?rdfs_label ;
         skos:altLabel ?schema_name ;
         skos:altLabel ?schema_alternateName ;
-        skos:scopeNote ?schema_description .
+        skos:scopeNote ?scopeNote .
 }
 WHERE {
     ?uri schema:mainEntityOfPage/schema:isPartOf <http://data.bibliotheken.nl/id/dataset/stcn/printers> ;
@@ -16,9 +18,17 @@ WHERE {
     ?uri ?predicate ?label .
     VALUES ?predicate { rdfs:label schema:name schema:alternateName }
     ?label <bif:contains> ?virtuosoQuery .
-
+    # STCN defines multiple URIs for the same printer.
+    # The distinction between these URIs is based on the place where the printer lived and worked.
+    # See for example "Plantijn"
+    # http://data.bibliotheken.nl/id/thes/p075556251 for Plantijn working in Leiden
+    # http://data.bibliotheken.nl/id/thes/p338012834 for Plantijn working in Antwerp
+    # The original source (STCN) shows also a time period, this data currently not available in the LOD version.
+    OPTIONAL { 
+     ?uri schema:location/schema:address/schema:addressLocality ?place 
+    }
+    BIND(COALESCE(IF(BOUND(?place), ?place, ?noPlace)) as ?scopeNote)
     OPTIONAL { ?uri schema:name ?schema_name }
     OPTIONAL { ?uri schema:alternateName ?schema_alternateName }
-    OPTIONAL { ?uri schema:description ?schema_description }
 }
 LIMIT 1000


### PR DESCRIPTION
Added location info to lookup and search query, this fixes #500. We should also add time periods in which printers were active but these are not yet available in the Linked Data. 