### PR TITLE
fix: Build failure due to npm ci

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 .github
-**/node_modules/
+node_modules/
 **/build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ RUN npm ci
 # Install the workspace’s dependencies. Any dependencies on other internal workspaces must be published packages.
 # Workspaces have no package-lock.json so we must use npm install rather than npm ci.
 COPY $PACKAGE_DIR/package.json ./$PACKAGE_DIR/
-COPY package-lock.json ./$PACKAGE_DIR
-RUN npm ci --prefix $PACKAGE_DIR
+RUN npm install --prefix $PACKAGE_DIR
 
 COPY . .
 RUN NODE_ENV=production npm run compile --workspace $PACKAGE_DIR

--- a/package-lock.json
+++ b/package-lock.json
@@ -17488,21 +17488,21 @@
       "name": "@netwerk-digitaal-erfgoed/network-of-terms-graphql",
       "license": "EUPL",
       "dependencies": {
-        "@fastify/cors": "^8.0.0",
-        "@hapi/hoek": "^10.0.0",
+        "@fastify/cors": "8.0.0",
+        "@hapi/hoek": "10.0.0",
         "@netwerk-digitaal-erfgoed/network-of-terms-catalog": "*",
         "@netwerk-digitaal-erfgoed/network-of-terms-query": "*",
-        "@rdfjs/data-model": "^2.0.1",
-        "fastify": "^4.0.2",
-        "joi": "^17.6.0",
-        "mercurius": "^10.0.0"
+        "@rdfjs/data-model": "2.0.1",
+        "fastify": "4.0.2",
+        "joi": "17.6.0",
+        "mercurius": "10.0.0"
       },
       "devDependencies": {
-        "@types/jest-dev-server": "^5.0.0",
-        "@types/rdfjs__data-model": "^2.0.1",
-        "jest-dev-server": "^6.0.3",
-        "ts-node-dev": "^2.0.0",
-        "tsc-watch": "^5.0.3"
+        "@types/jest-dev-server": "5.0.0",
+        "@types/rdfjs__data-model": "2.0.1",
+        "jest-dev-server": "6.0.3",
+        "ts-node-dev": "2.0.0",
+        "tsc-watch": "5.0.3"
       },
       "engines": {
         "node": ">=16.15.0"
@@ -21458,19 +21458,19 @@
     "@netwerk-digitaal-erfgoed/network-of-terms-graphql": {
       "version": "file:packages/network-of-terms-graphql",
       "requires": {
-        "@fastify/cors": "^8.0.0",
-        "@hapi/hoek": "^10.0.0",
+        "@fastify/cors": "8.0.0",
+        "@hapi/hoek": "10.0.0",
         "@netwerk-digitaal-erfgoed/network-of-terms-catalog": "*",
         "@netwerk-digitaal-erfgoed/network-of-terms-query": "*",
-        "@rdfjs/data-model": "^2.0.1",
-        "@types/jest-dev-server": "^5.0.0",
-        "@types/rdfjs__data-model": "^2.0.1",
-        "fastify": "^4.0.2",
-        "jest-dev-server": "^6.0.3",
-        "joi": "^17.6.0",
-        "mercurius": "^10.0.0",
-        "ts-node-dev": "^2.0.0",
-        "tsc-watch": "^5.0.3"
+        "@rdfjs/data-model": "2.0.1",
+        "@types/jest-dev-server": "5.0.0",
+        "@types/rdfjs__data-model": "2.0.1",
+        "fastify": "4.0.2",
+        "jest-dev-server": "6.0.3",
+        "joi": "17.6.0",
+        "mercurius": "10.0.0",
+        "ts-node-dev": "2.0.0",
+        "tsc-watch": "5.0.3"
       },
       "dependencies": {
         "@fastify/static": {

--- a/packages/network-of-terms-graphql/package.json
+++ b/packages/network-of-terms-graphql/package.json
@@ -7,21 +7,21 @@
     "build/"
   ],
   "dependencies": {
-    "@fastify/cors": "^8.0.0",
-    "@hapi/hoek": "^10.0.0",
+    "@fastify/cors": "8.0.0",
+    "@hapi/hoek": "10.0.0",
     "@netwerk-digitaal-erfgoed/network-of-terms-catalog": "*",
     "@netwerk-digitaal-erfgoed/network-of-terms-query": "*",
-    "@rdfjs/data-model": "^2.0.1",
-    "fastify": "^4.0.2",
-    "joi": "^17.6.0",
-    "mercurius": "^10.0.0"
+    "@rdfjs/data-model": "2.0.1",
+    "fastify": "4.0.2",
+    "joi": "17.6.0",
+    "mercurius": "10.0.0"
   },
   "devDependencies": {
-    "@types/jest-dev-server": "^5.0.0",
-    "@types/rdfjs__data-model": "^2.0.1",
-    "jest-dev-server": "^6.0.3",
-    "ts-node-dev": "^2.0.0",
-    "tsc-watch": "^5.0.3"
+    "@types/jest-dev-server": "5.0.0",
+    "@types/rdfjs__data-model": "2.0.1",
+    "jest-dev-server": "6.0.3",
+    "ts-node-dev": "2.0.0",
+    "tsc-watch": "5.0.3"
   },
   "scripts": {
     "check": "gts check",

--- a/packages/network-of-terms-reconciliation/package.json
+++ b/packages/network-of-terms-reconciliation/package.json
@@ -6,19 +6,19 @@
     "url": "https://github.com/netwerk-digitaal-erfgoed/network-of-terms/issues"
   },
   "dependencies": {
-    "@fastify/accepts": "^4.0.0",
-    "@fastify/cors": "^8.0.0",
-    "@fastify/formbody": "^7.0.1",
-    "@hapi/hoek": "^10.0.0",
+    "@fastify/accepts": "4.0.0",
+    "@fastify/cors": "8.0.0",
+    "@fastify/formbody": "7.0.1",
+    "@hapi/hoek": "10.0.0",
     "@netwerk-digitaal-erfgoed/network-of-terms-catalog": "*",
     "@netwerk-digitaal-erfgoed/network-of-terms-query": "*",
-    "fastify": "^4.0.2",
-    "string-comparison": "^1.1.0"
+    "fastify": "4.0.2",
+    "string-comparison": "1.1.0"
   },
   "devDependencies": {
-    "@types/accepts": "^1.3.5",
-    "accepts": "^1.3.8",
-    "jest-dev-server": "^6.0.3"
+    "@types/accepts": "1.3.5",
+    "accepts": "1.3.8",
+    "jest-dev-server": "6.0.3"
   },
   "files": [
     "build/"


### PR DESCRIPTION
- Revert "fix: Install package dependencies deterministically"
- Use exact versions in package.json to fix `npm ci can only 
  install packages when your package.json and package-lock.json 
  or npm-shrinkwrap.json are in sync. Please update your lock file
  with npm install before continuing.`
