### PR TITLE
replaced namespace and decreased limit

### DIFF
--- a/packages/network-of-terms-catalog/catalog/queries/search/gtaa.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/gtaa.rq
@@ -1,5 +1,5 @@
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-PREFIX openskos:  <http://openskos.org/xmlns#>
+PREFIX bengthes: <http://data.beeldengeluid.nl/schema/thes#>
 PREFIX text: <http://jena.apache.org/text#>
 
 CONSTRUCT {
@@ -18,7 +18,7 @@ CONSTRUCT {
 WHERE {
     ?uri text:query (skos:prefLabel skos:altLabel skos:hiddenLabel ?query) .
     ?uri skos:inScheme ?datasetUri ;
-        openskos:status ?status .
+        bengthes:status ?status .
     FILTER(?status IN ('approved', 'candidate'))
 
     OPTIONAL {
@@ -53,4 +53,4 @@ WHERE {
         FILTER(LANG(?related_prefLabel) = "nl")
     }
 }
-LIMIT 1000
+LIMIT 10


### PR DESCRIPTION
The namespace for the B&G properties is now published and the queries need to use it to work.

Also, the LIMIT was still on 1000, which seemed appropriate when the query seemed to limit the number of triples in the construct query. Now we have changed the query to use the full text capabilities, the LIMIT seems to be the number of concepts. Note that the Jena results are not ranked, but when the limit is set to 10, the 10 most relevant results are returned (although unordered). When using a limit 1000 the best result may end up on place 1000 in the worst case.

We use the Apache Lucene full text engine on Apache Jena triple store. This is able to send relevance information, which can be used to sort the results. Currently, the network of terms is not using such functionality. We could provide example queries and results that contain the relevance scores, so that the result list can be sorted. Please send a message when interested. For now we just suggest to bring down the number of results drastically, because that will improve the search. 

