### PR TITLE
feat: Sort by relevance score if available

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,3 +8,7 @@ This repository follows [Semantic Versioning](https://semver.org). Tags and [rel
 [created automatically](.github/workflows/release.yml) based on commit messages. So please make sure to follow
 the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) when committing
 changes.
+
+## Adding a terminology source
+
+Please see the [network-of-terms-catalog package](packages/network-of-terms-catalog/).

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,10 +11,10 @@ export default {
   ],
   coverageThreshold: {
     global: {
-      lines: 90.19,
-      statements: 90.19,
-      branches: 96.25,
-      functions: 89.36,
+      lines: 90.26,
+      statements: 90.26,
+      branches: 94.11,
+      functions: 89.47,
     },
   },
   transform: {

--- a/packages/network-of-terms-catalog/README.md
+++ b/packages/network-of-terms-catalog/README.md
@@ -34,7 +34,9 @@ two types of queries:
 
 * Create a `your-dataset.jsonld` file in the `catalog/` directory and add a description.
 * Create a `your-dataset.rq` file in the `queries/search` directory and add your SPARQL search query. A SPARQL
-  lookup goes into the `queries/lookup` directory.
+  lookup query goes into the `queries/lookup` directory.
+  * If your SPARQL server supports fulltext search relevance scores, you can return them as `vrank:simpleRank` values to
+    have search results ordered by rank instead of the default, alphabetical order.
 * [Run the tests](../../docs/tests.md) to make sure your dataset description conforms to the
   [dataset SHACL](shacl/dataset.jsonld).
 * To try your queries locally, you can

--- a/packages/network-of-terms-catalog/catalog/queries/search/gtaa.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/gtaa.rq
@@ -1,6 +1,7 @@
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX bengthes: <http://data.beeldengeluid.nl/schema/thes#>
 PREFIX text: <http://jena.apache.org/text#>
+PREFIX vrank: <http://purl.org/voc/vrank#>
 
 CONSTRUCT {
     ?uri a skos:Concept ;
@@ -10,13 +11,14 @@ CONSTRUCT {
         skos:scopeNote ?scopeNote ;
         skos:broader ?broader_uri ;
         skos:narrower ?narrower_uri ;
-        skos:related ?related_uri .
+        skos:related ?related_uri ;
+        vrank:simpleRank ?score .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
     ?related_uri skos:prefLabel ?related_prefLabel .
 }
 WHERE {
-    ?uri text:query (skos:prefLabel skos:altLabel skos:hiddenLabel ?query) .
+    (?uri ?score) text:query (skos:prefLabel skos:altLabel skos:hiddenLabel ?query) .
     ?uri skos:inScheme ?datasetUri ;
         bengthes:status ?status .
     FILTER(?status IN ('approved', 'candidate'))
@@ -53,4 +55,5 @@ WHERE {
         FILTER(LANG(?related_prefLabel) = "nl")
     }
 }
+ORDER BY DESC(?score)
 LIMIT 10

--- a/packages/network-of-terms-graphql/test/server.test.ts
+++ b/packages/network-of-terms-graphql/test/server.test.ts
@@ -97,6 +97,17 @@ describe('Server', () => {
     );
     expect(artwork.seeAlso).toEqual(['https://example.com/html/artwork']);
 
+    const prefLabels = body.data.terms[0].result.terms.map(
+      ({prefLabel}: {prefLabel: string[]}) => prefLabel[0] ?? ''
+    );
+    expect(prefLabels).toEqual([
+      'Rembrandt',
+      'Nachtwacht',
+      'All things art',
+      '',
+      '',
+    ]); // Results with score must come first.
+
     const relatedPrefLabels = artwork.related.map(
       ({prefLabel}: {prefLabel: string[]}) => prefLabel[0] ?? ''
     );

--- a/packages/network-of-terms-query/src/query.ts
+++ b/packages/network-of-terms-query/src/query.ts
@@ -144,7 +144,9 @@ export class QueryTermsService {
         termsTransformer.fromQuad(quad);
       });
       quadStream.on('end', () => {
-        const terms = termsTransformer.asArray().sort(alphabeticallyByLabels);
+        const terms = termsTransformer
+          .asArray()
+          .sort(byScoreThenAlphabetically);
         this.logger.info(
           `Found ${terms.length} terms matching "${query}" in "${
             distribution.endpoint
@@ -160,6 +162,16 @@ export class QueryTermsService {
     });
   }
 }
+
+const byScoreThenAlphabetically = (a: Term, b: Term) => {
+  const scoreA = a.score?.value || 0;
+  const scoreB = b.score?.value || 0;
+  if (scoreA === scoreB) {
+    return alphabeticallyByLabels(a, b);
+  } else {
+    return scoreA < scoreB ? 1 : -1;
+  }
+};
 
 const alphabeticallyByLabels = (a: Term, b: Term) => {
   const prefLabelA = a.prefLabels[0]?.value ?? '';

--- a/packages/network-of-terms-query/src/terms.ts
+++ b/packages/network-of-terms-query/src/terms.ts
@@ -12,7 +12,8 @@ export class Term {
     readonly broaderTerms: RelatedTerm[],
     readonly narrowerTerms: RelatedTerm[],
     readonly relatedTerms: RelatedTerm[],
-    readonly datasetIri: RDF.Term | undefined
+    readonly datasetIri: RDF.Term | undefined,
+    readonly score: RDF.Literal | undefined
   ) {}
 }
 
@@ -32,6 +33,7 @@ class SparqlResultTerm {
   narrowerTerms: RDF.Term[] = [];
   relatedTerms: RDF.Term[] = [];
   inScheme: RDF.Term | undefined = undefined;
+  score: RDF.Literal | undefined = undefined;
 }
 
 export class TermsTransformer {
@@ -55,6 +57,7 @@ export class TermsTransformer {
     ['http://www.w3.org/2004/02/skos/core#related', 'relatedTerms'],
     ['http://www.w3.org/2008/05/skos#related', 'relatedTerms'],
     ['http://www.w3.org/2004/02/skos/core#inScheme', 'inScheme'],
+    ['http://purl.org/voc/vrank#simpleRank', 'score'],
   ]);
 
   fromQuad(quad: RDF.Quad): void {
@@ -103,7 +106,8 @@ export class TermsTransformer {
           alphabeticallyByPrefLabel
         ),
         this.mapRelatedTerms(term.relatedTerms).sort(alphabeticallyByPrefLabel),
-        term.inScheme
+        term.inScheme,
+        term.score
       );
     });
   }

--- a/packages/network-of-terms-query/test/fixtures/terms.ttl
+++ b/packages/network-of-terms-query/test/fixtures/terms.ttl
@@ -1,5 +1,6 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix vrank: <http://purl.org/voc/vrank#> .
 
 <https://example.com/resources/artwork>
     a skos:Concept ;
@@ -12,7 +13,8 @@
         <https://example.com/resources/painting> ,
         <https://example.com/resources/art> ;
     skos:ignored "Not used by Network of Terms" ;
-    rdfs:seeAlso <https://example.com/html/artwork> .
+    rdfs:seeAlso <https://example.com/html/artwork> ;
+    vrank:simpleRank 18.0 .
 
 <https://example.com/resources/painting>
     a <http://www.w3.org/2008/05/skos#Concept> ;
@@ -24,7 +26,8 @@
 
 <https://example.com/resources/painter>
     a <http://www.w3.org/2008/05/skos#Concept> ;
-    skos:prefLabel "Rembrandt" .
+    skos:prefLabel "Rembrandt" ;
+    vrank:simpleRank 20.5 .
 
 <https://example.com/resources/art>
     a skos:Concept ;


### PR DESCRIPTION
* Queries may sort by relevance score.
* If they do, sort by score primarily. For identical scores, fall back to alphabetical sort.
* If they do not, only sort alphabetically.
* This PR does not yet expose the score in the GraphQL API.

Fix #537 