### PR TITLE
Update SPARQL lookup and search query for brabantse-gebouwen

### DIFF
--- a/packages/network-of-terms-catalog/catalog/queries/lookup/brabantse-gebouwen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/brabantse-gebouwen.rq
@@ -5,9 +5,8 @@ CONSTRUCT {
     ?uri a skos:Concept ;
         skos:prefLabel ?schema_name ;
         skos:altLabel ?schema_alternateName ;
-        skos:scopeNote ?schema_description,
-                       ?buildingTypeScopeNote,
-                       ?addressScopeNote .
+        skos:hiddenLabel ?hiddenLabel;
+        skos:scopeNote ?schema_description, ?scopeNote .
 }
 WHERE {
     # For example:
@@ -20,24 +19,7 @@ WHERE {
     OPTIONAL { ?uri schema:name ?schema_name }
     OPTIONAL { ?uri schema:alternateName ?schema_alternateName }
     OPTIONAL { ?uri schema:description ?schema_description }
-    OPTIONAL {
-        ?uri schema:additionalType <http://vocab.getty.edu/aat/300000641> .
-        BIND("Type: kloostergebouw" AS ?buildingTypeScopeNote)
-    }
-    OPTIONAL {
-        ?uri schema:address ?address .
-        OPTIONAL { ?address schema:streetAddress ?streetAddress }
-        OPTIONAL { ?address schema:addressLocality ?addressLocality }
-        OPTIONAL { ?address schema:addressRegion ?addressRegion }
-        BIND(
-            COALESCE(
-                IF(?streetAddress && ?addressLocality && ?addressRegion, CONCAT("Adres: ", ?streetAddress, ", ", ?addressLocality, ", ", ?addressRegion), ?noAddress),
-                IF(?streetAddress && ?addressLocality, CONCAT("Adres: ", ?streetAddress, ", ", ?addressLocality), ?noAddress),
-                IF(?streetAddress, CONCAT("Adres: ", ?streetAddress), ?noAddress),
-                IF(?addressLocality && ?addressRegion, CONCAT("Plaats: ", ?addressLocality, ", ", ?addressRegion), ?noAddress),
-                IF(?addressLocality, CONCAT("Plaats: ", ?addressLocality), ?noAddress)
-            ) AS ?addressScopeNote
-        )
-    }
+    OPTIONAL { ?uri skos:hiddenLabel ?hiddenLabel }
+    OPTIONAL { ?uri skos:scopeNote ?scopeNote}
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/brabantse-gebouwen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/brabantse-gebouwen.rq
@@ -5,9 +5,8 @@ CONSTRUCT {
     ?uri a skos:Concept ;
         skos:prefLabel ?schema_name ;
         skos:altLabel ?schema_alternateName ;
-        skos:scopeNote ?schema_description,
-                       ?buildingTypeScopeNote,
-                       ?addressScopeNote .
+        skos:hiddenLabel ?hiddenLabel;
+        skos:scopeNote ?schema_description, ?scopeNote .
 }
 WHERE {
     ?uri a schema:LandmarksOrHistoricalBuildings .
@@ -15,26 +14,9 @@ WHERE {
     VALUES ?predicate { schema:name schema:alternateName }
     FILTER(CONTAINS(LCASE(?label), LCASE(?query)))
     OPTIONAL { ?uri schema:name ?schema_name }
+    OPTIONAL { ?uri skos:hiddenLabel ?hiddenLabel }
+    OPTIONAL { ?uri skos:scopeNote ?scopeNote}
     OPTIONAL { ?uri schema:alternateName ?schema_alternateName }
     OPTIONAL { ?uri schema:description ?schema_description }
-    OPTIONAL {
-        ?uri schema:additionalType <http://vocab.getty.edu/aat/300000641> .
-        BIND("Type: kloostergebouw" AS ?buildingTypeScopeNote)
-    }
-    OPTIONAL {
-        ?uri schema:address ?address .
-        OPTIONAL { ?address schema:streetAddress ?streetAddress }
-        OPTIONAL { ?address schema:addressLocality ?addressLocality }
-        OPTIONAL { ?address schema:addressRegion ?addressRegion }
-        BIND(
-            COALESCE(
-                IF(?streetAddress && ?addressLocality && ?addressRegion, CONCAT("Adres: ", ?streetAddress, ", ", ?addressLocality, ", ", ?addressRegion), ?noAddress),
-                IF(?streetAddress && ?addressLocality, CONCAT("Adres: ", ?streetAddress, ", ", ?addressLocality), ?noAddress),
-                IF(?streetAddress, CONCAT("Adres: ", ?streetAddress), ?noAddress),
-                IF(?addressLocality && ?addressRegion, CONCAT("Plaats: ", ?addressLocality, ", ", ?addressRegion), ?noAddress),
-                IF(?addressLocality, CONCAT("Plaats: ", ?addressLocality), ?noAddress)
-            ) AS ?addressScopeNote
-        )
-    }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/brabantse-gebouwen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/brabantse-gebouwen.rq
@@ -11,7 +11,7 @@ CONSTRUCT {
 WHERE {
     ?uri a schema:LandmarksOrHistoricalBuildings .
     ?uri ?predicate ?label .
-    VALUES ?predicate { schema:name schema:alternateName }
+    VALUES ?predicate { schema:name schema:alternateName skos:hiddenLabel skos:scopeNote}
     FILTER(CONTAINS(LCASE(?label), LCASE(?query)))
     OPTIONAL { ?uri schema:name ?schema_name }
     OPTIONAL { ?uri skos:hiddenLabel ?hiddenLabel }


### PR DESCRIPTION
refactor(brabantse-gebouwen.rq): replace skos:altLabel with skos:hiddenLabel and simplify skos:scopeNote

refactor(brabantse-gebouwen.rq): remove buildingTypeScopeNote and addressScopeNote, add hiddenLabel and scopeNote to CONSTRUCT

The queries have been simplified because the information is now available in the source endpoint.
