### PR TITLE
fix: Trust Forwarded headers for getting protocol

### DIFF
--- a/packages/network-of-terms-reconciliation/src/server.ts
+++ b/packages/network-of-terms-reconciliation/src/server.ts
@@ -33,7 +33,7 @@ export async function server(catalog: Catalog): Promise<FastifyInstance> {
   const queryTermsService = new QueryTermsService();
   const lookupService = new LookupService(catalog, queryTermsService);
 
-  const server = fastify({logger});
+  const server = fastify({logger, trustProxy: true});
   server.register(fastifyCors);
   server.register(formBodyPlugin, {parser});
   server.register(fastifyAccepts);


### PR DESCRIPTION
Reconciliation services (e.g. https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/https://demo.netwerkdigitaalerfgoed.nl/geonames)
show HTTP instead of HTTPS as the protocol.
This is probably because the Forwarded/X-Forwarded-Proto
headers set by our reverse proxy are not trusted by Fastify by default.