### PR TITLE
feat: Raise max query timeout

### DIFF
--- a/packages/network-of-terms-graphql/README.md
+++ b/packages/network-of-terms-graphql/README.md
@@ -219,3 +219,24 @@ query {
   }
 }
 ```
+
+### Response times and timeout
+
+Response times from the Network of Terms will vary depending on how fast each terminology source returns results for the
+query.
+
+Use the `responseTimeMs` query parameter to inspect the response time for each source.
+
+The default timeout is 5 seconds. You can raise this up till `MAX_QUERY_TIMEOUT` (60 seconds, by default) using the
+`timeoutMs` query parameter. For example, to wait a maximum of 15 seconds for each terminology source to respond:
+
+```graphql
+query {
+  terms(
+    sources: [...],
+    query: "...",
+    timeoutMs: 15000,
+  ) {
+    ...
+  }
+}

--- a/packages/network-of-terms-query/src/query.ts
+++ b/packages/network-of-terms-query/src/query.ts
@@ -89,7 +89,7 @@ export class QueryTermsService {
       Joi.number()
         .integer()
         .min(1)
-        .max(parseInt(process.env.MAX_QUERY_TIMEOUT as string) || 10000)
+        .max(parseInt(process.env.MAX_QUERY_TIMEOUT as string) || 60000)
         .default(parseInt(process.env.DEFAULT_QUERY_TIMEOUT as string) || 5000)
     );
 


### PR DESCRIPTION
For example
https://termennetwerk.netwerkdigitaalerfgoed.nl/?q=dorp\&datasets=https://query.wikidata.org/sparql%23entities-streets
needs longer than our current max timeout of 10 sec.
