### PR TITLE
fix: Failed to translate metric

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,8 +11,8 @@ export default {
   ],
   coverageThreshold: {
     global: {
-      lines: 90.84,
-      statements: 90.84,
+      lines: 90.81,
+      statements: 90.81,
       branches: 93.81,
       functions: 89.79,
     },

--- a/packages/network-of-terms-query/src/instrumentation.ts
+++ b/packages/network-of-terms-query/src/instrumentation.ts
@@ -1,8 +1,6 @@
 import {
-  ExponentialHistogramAggregation,
   MeterProvider,
   PeriodicExportingMetricReader,
-  View,
 } from '@opentelemetry/sdk-metrics';
 import {Resource} from '@opentelemetry/resources';
 import {OTLPMetricExporter} from '@opentelemetry/exporter-metrics-otlp-proto';
@@ -17,12 +15,6 @@ const meterProvider = new MeterProvider({
       [SemanticResourceAttributes.SERVICE_NAME]: 'network-of-terms',
     })
   ),
-  views: [
-    new View({
-      aggregation: new ExponentialHistogramAggregation(10),
-      instrumentName: sourceQueriesHistogramName,
-    }),
-  ],
 });
 
 if ('test' !== process.env.NODE_ENV) {


### PR DESCRIPTION
While I prefer an exponential histogram because it manages buckets
automatically, it causes the OpenTelemetry collector to throw
`failed to translate metric`.

Because the default bucket sizes have been fixed in sdk-metrics 1.15.0,
they have become useful enough to just use them: https://github.com/open-telemetry/opentelemetry-js/pull/3893/ 

Compare https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13443
