### PR TITLE
feat: Update Muziekschatten namespace

### DIFF
--- a/packages/network-of-terms-catalog/catalog/datasets/muziekschatten-onderwerpen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/muziekschatten-onderwerpen.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org/docs/jsonldcontext.jsonld",
-  "@id": "http://data.muziekschatten.nl/#onderwerpen",
+  "@id": "https://data.muziekschatten.nl/#onderwerpen",
   "@type": "Dataset",
   "name": [
     {

--- a/packages/network-of-terms-catalog/catalog/datasets/muziekschatten-personen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/muziekschatten-personen.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org/docs/jsonldcontext.jsonld",
-  "@id": "http://data.muziekschatten.nl/#personen",
+  "@id": "https://data.muziekschatten.nl/#personen",
   "@type": "Dataset",
   "name": [
     {

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/muziekschatten.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/muziekschatten.rq
@@ -1,6 +1,6 @@
 PREFIX schema: <http://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-PREFIX som: <http://data.muziekschatten.nl/som/>
+PREFIX som: <https://data.muziekschatten.nl/som/>
 
 CONSTRUCT {
     ?uri a skos:Concept ;
@@ -53,7 +53,7 @@ WHERE {
     # For subjects
     OPTIONAL {
         ?uri a skos:Concept
-        BIND(<http://data.muziekschatten.nl/#onderwerpen> AS ?datasetUri).
+        BIND(<https://data.muziekschatten.nl/#onderwerpen> AS ?datasetUri).
 
         OPTIONAL {
             ?uri schema:name ?schema_name .
@@ -83,7 +83,7 @@ WHERE {
     # For persons
     OPTIONAL {
         ?uri a schema:Person
-        BIND(<http://data.muziekschatten.nl/#personen> AS ?datasetUri).
+        BIND(<https://data.muziekschatten.nl/#personen> AS ?datasetUri).
         OPTIONAL { ?uri schema:name ?schema_name }
         OPTIONAL { ?uri schema:alternateName ?altLabel }
         OPTIONAL { ?uri schema:hasOccupation ?schema_hasOccupation }

--- a/packages/network-of-terms-catalog/catalog/queries/search/muziekschatten-onderwerpen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/muziekschatten-onderwerpen.rq
@@ -1,6 +1,6 @@
 PREFIX schema: <http://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-PREFIX som: <http://data.muziekschatten.nl/som/>
+PREFIX som: <https://data.muziekschatten.nl/som/>
 
 CONSTRUCT {
     ?uri a skos:Concept;

--- a/packages/network-of-terms-catalog/catalog/queries/search/muziekschatten-personen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/muziekschatten-personen.rq
@@ -1,6 +1,6 @@
 PREFIX schema: <http://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-PREFIX som: <http://data.muziekschatten.nl/som/>
+PREFIX som: <https://data.muziekschatten.nl/som/>
 
 # Persons for testing the query
 # No birth year:


### PR DESCRIPTION
Muziekschatten has switched to https://, so update our
references.
