### PR TITLE
improve full text search for Geonames

### DIFF
--- a/packages/network-of-terms-catalog/catalog/queries/search/geonames.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/geonames.rq
@@ -11,7 +11,7 @@ CONSTRUCT {
     ?broader skos:prefLabel ?broader_prefLabel .
 }
 WHERE {
-    ?uri text:query (gn:name gn:alternateName ?query) ;
+    ?uri text:query ?virtuosoQuery ;
         a gn:Feature ;
         gn:featureClass ?featureClass ;
         gn:name ?prefLabel ;


### PR DESCRIPTION
Used `?virtuosoQuery` for Geonames query to improve support for search with phrases like `'gent sas van'.` Should not have any impact on single term searches, did some testing to confirm this. The `?virtuosoQuery` seems not to go well with the more complex `text:query` options using '`( ... )'`, had to remove this from the query but seemed redundant anyway. 