### PR TITLE
revert: "test: Fix tests when run in Docker container (#1049)"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,5 @@ services:
       - .:/app
     ports:
       - "3123:3123"
-      - "3000:3000"
-      - "3001:3001"
     working_dir: /app
     command: bash


### PR DESCRIPTION
This reverts commit ba7ebdeb5ef7a1e6a27677b20899d8f6e93b0e31.

These ports should not be needed when running the tests in Docker.
Note that #1048 was solved differently, in #1050.

Fix #1068
