### PR TITLE
feat: Remove deprecated query mode

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,7 @@ export default {
     global: {
       lines: 90.87,
       statements: 90.87,
-      branches: 93.89,
+      branches: 93.83,
       functions: 89.79,
     },
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,9 +11,9 @@ export default {
   ],
   coverageThreshold: {
     global: {
-      lines: 90.83,
-      statements: 90.83,
-      branches: 93.85,
+      lines: 90.87,
+      statements: 90.87,
+      branches: 93.89,
       functions: 89.79,
     },
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "compile": "npm run compile --workspaces",
     "check": "gts check",
     "fix": "gts fix",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest ${1} --runInBand",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest ${1}",
     "posttest": "jest-coverage-thresholds-bumper --silent",
     "release": "npx multi-semantic-release"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "compile": "npm run compile --workspaces",
     "check": "gts check",
     "fix": "gts fix",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest ${1}",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest ${1} --runInBand",
     "posttest": "jest-coverage-thresholds-bumper --silent",
     "release": "npx multi-semantic-release"
   },

--- a/packages/network-of-terms-catalog/catalog/queries/search/adamlink-straten.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/adamlink-straten.rq
@@ -13,19 +13,7 @@ WHERE {
     ?uri a hg:Street .
     ?uri ?predicate ?label .
     VALUES ?predicate { skos:prefLabel skos:altLabel }
-
-    {
-        FILTER(?virtuosoQuery)
-        ?uri ?predicate ?label .
-        ?label <bif:contains> ?virtuosoQuery .
-    } UNION {
-        # BC support.
-        BIND(?virtuosoQuery as ?b)
-        FILTER(!BOUND(?b))
-        ?uri ?predicate ?label .
-        # Replace query "A B" with "A AND B", leaving queries "A AND B" or "A OR B" unchanged.
-        FILTER (<bif:contains> (?label, REPLACE(?query, "(?<!AND)(?<!OR)[[:space:]]+(?!AND)(?!OR)", " AND ", "i")) )
-    }
+    ?label <bif:contains> ?virtuosoQuery .
 
     OPTIONAL { ?uri skos:prefLabel ?prefLabel }
     OPTIONAL { ?uri skos:altLabel ?altLabel }

--- a/packages/network-of-terms-catalog/catalog/queries/search/brinkman.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/brinkman.rq
@@ -21,19 +21,7 @@ WHERE {
     ?uri ?predicate ?label .
     VALUES ?predicate { skos:prefLabel skos:altLabel }
     FILTER(LANG(?label) = "nl")
-
-    {
-        FILTER(?virtuosoQuery)
-        ?uri ?predicate ?label .
-        ?label <bif:contains> ?virtuosoQuery .
-    } UNION {
-        # BC support.
-        BIND(?virtuosoQuery as ?b)
-        FILTER(!BOUND(?b))
-        ?uri ?predicate ?label .
-        # Replace query "A B" with "A AND B", leaving queries "A AND B" or "A OR B" unchanged.
-        FILTER (<bif:contains> (?label, REPLACE(?query, "(?<!AND)(?<!OR)[[:space:]]+(?!AND)(?!OR)", " AND ", "i")))
-    }
+    ?label <bif:contains> ?virtuosoQuery .
 
     OPTIONAL {
         ?uri skos:prefLabel ?prefLabel .

--- a/packages/network-of-terms-catalog/catalog/queries/search/muziekschatten-onderwerpen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/muziekschatten-onderwerpen.rq
@@ -10,22 +10,11 @@ CONSTRUCT {
     ?broader_uri skos:prefLabel ?broader_schema_name .
 }
 WHERE {
-    ?uri a skos:Concept .
+    ?uri a skos:Concept ;
+        ?predicate ?label .
 
-    {
-        FILTER(?virtuosoQuery)
-        ?uri ?predicate ?label .
-        VALUES ?predicate { schema:name schema:keywords }
-        ?label <bif:contains> ?virtuosoQuery .
-    } UNION {
-        # BC support.
-        # This Virtuoso endpoint needs STRLEN() rather than !BOUND() because the latter still matches, throwing an error
-        # for queries with diacritics or multiple words.
-        FILTER(STRLEN(?virtuosoQuery) = 0)
-        ?uri ?predicate ?label .
-        VALUES ?predicate { schema:name schema:keywords }
-        ?label <bif:contains> ?query .
-    }
+    VALUES ?predicate { schema:name schema:keywords }
+    ?label <bif:contains> ?virtuosoQuery .
 
     OPTIONAL {
         ?uri schema:name ?schema_name .

--- a/packages/network-of-terms-catalog/catalog/queries/search/muziekschatten-personen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/muziekschatten-personen.rq
@@ -29,22 +29,10 @@ CONSTRUCT {
 WHERE {
     ?uri a schema:Person .
     # Require the presence of this property for quality purposes
-    ?uri som:NDEREC ?nderec .
-
-    {
-        FILTER(?virtuosoQuery)
-        ?uri ?predicate ?label .
-        VALUES ?predicate { schema:name schema:alternateName }
-        ?label <bif:contains> ?virtuosoQuery .
-    } UNION {
-        # BC support.
-        # This Virtuoso endpoint needs STRLEN() rather than !BOUND() because the latter still matches, throwing an error
-        # for queries with diacritics or multiple words.
-        FILTER(STRLEN(?virtuosoQuery) = 0)
-        ?uri ?predicate ?label .
-        VALUES ?predicate { schema:name schema:alternateName }
-        ?label <bif:contains> ?query .
-    }
+    ?uri som:NDEREC ?nderec ;
+        ?predicate ?label .
+    VALUES ?predicate { schema:name schema:alternateName }
+    ?label <bif:contains> ?virtuosoQuery .
 
     OPTIONAL { ?uri schema:name ?schema_name }
     OPTIONAL { ?uri schema:alternateName ?schema_alternateName }

--- a/packages/network-of-terms-catalog/catalog/queries/search/mw-genresstijlen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/mw-genresstijlen.rq
@@ -12,20 +12,9 @@ CONSTRUCT {
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
 }
 WHERE {
-    ?uri a muziekweb:Genre .
-
-    {
-        FILTER(?virtuosoQuery)
-        ?uri rdfs:label ?rdfs_label .
-        ?rdfs_label <bif:contains> ?virtuosoQuery .
-    } UNION {
-        # BC support.
-        BIND(?virtuosoQuery as ?b)
-        FILTER(!BOUND(?b))
-        ?uri rdfs:label ?rdfs_label .
-        # Replace query "A B" with "A AND B", leaving queries "A AND B" or "A OR B" unchanged.
-        FILTER (<bif:contains> (?rdfs_label, REPLACE(?query, "(?<!AND)(?<!OR)[[:space:]]+(?!AND)(?!OR)", " AND ", "i")) )
-    }
+    ?uri a muziekweb:Genre ;
+        rdfs:label ?rdfs_label .
+    ?rdfs_label <bif:contains> ?virtuosoQuery .
 
     OPTIONAL {
         ?uri skos:broader ?broader_uri .

--- a/packages/network-of-terms-catalog/catalog/queries/search/mw-personengroepen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/mw-personengroepen.rq
@@ -10,22 +10,10 @@ CONSTRUCT {
         skos:scopeNote ?schema_description .
 }
 WHERE {
-    ?uri a schema:MusicGroup .
-    ?uri ?predicate ?label .
+    ?uri a schema:MusicGroup ;
+        ?predicate ?label .
     VALUES ?predicate { skos:prefLabel skos:altLabel }
-
-    {
-        FILTER(?virtuosoQuery)
-        ?uri ?predicate ?label .
-        ?label <bif:contains> ?virtuosoQuery .
-    } UNION {
-        # BC support.
-        BIND(?virtuosoQuery as ?b)
-        FILTER(!BOUND(?b))
-        ?uri ?predicate ?label .
-        # Replace query "A B" with "A AND B", leaving queries "A AND B" or "A OR B" unchanged.
-        FILTER (<bif:contains> (?label, REPLACE(?query, "(?<!AND)(?<!OR)[[:space:]]+(?!AND)(?!OR)", " AND ", "i")) )
-    }
+    ?label <bif:contains> ?virtuosoQuery .
 
     OPTIONAL { ?uri skos:prefLabel ?prefLabel }
     OPTIONAL { ?uri skos:altLabel ?altLabel }

--- a/packages/network-of-terms-catalog/catalog/queries/search/nmvw.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/nmvw.rq
@@ -14,19 +14,7 @@ CONSTRUCT {
 WHERE {
     ?uri ?predicate ?label .
     VALUES ?predicate { skos:prefLabel skos:altLabel }
-
-    {
-        FILTER(?virtuosoQuery)
-        ?uri ?predicate ?label .
-        ?label <bif:contains> ?virtuosoQuery .
-    } UNION {
-        # BC support.
-        BIND(?virtuosoQuery as ?b)
-        FILTER(!BOUND(?b))
-        ?uri ?predicate ?label .
-        # Replace query "A B" with "A AND B", leaving queries "A AND B" or "A OR B" unchanged.
-        FILTER (<bif:contains> (?label, REPLACE(?query, "(?<!AND)(?<!OR)[[:space:]]+(?!AND)(?!OR)", " AND ", "i")) )
-    }
+    ?label <bif:contains> ?virtuosoQuery .
 
     OPTIONAL {
         ?uri skos:prefLabel ?prefLabel .

--- a/packages/network-of-terms-catalog/catalog/queries/search/nta.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/nta.rq
@@ -8,29 +8,10 @@ CONSTRUCT {
         skos:scopeNote ?schema_description .
 }
 WHERE {
-    ?uri schema:mainEntityOfPage/schema:isPartOf <http://data.bibliotheken.nl/id/dataset/persons> .
-    ?uri ?predicate ?label .
+    ?uri schema:mainEntityOfPage/schema:isPartOf <http://data.bibliotheken.nl/id/dataset/persons> ;
+        ?predicate ?label .
     VALUES ?predicate { rdfs:label schema:name schema:alternateName }
-
-    {
-        FILTER(?virtuosoQuery)
-        ?uri ?predicate ?label .
-        ?label <bif:contains> ?virtuosoQuery .
-    } UNION {
-        # BC support.
-        BIND(?virtuosoQuery as ?b)
-        FILTER(!BOUND(?b))
-        ?uri ?predicate ?label .
-        # Replace query "A B" with "A AND B", leaving queries "A AND B" or "A OR B" unchanged.
-        FILTER (<bif:contains> (?label,
-            REPLACE(
-                REPLACE(?query, "[.,]", " "),
-                "(?<!AND)(?<!OR)[[:space:]]+(?!AND)(?!OR)(?!$)(?![[:space:]])",
-                " AND ",
-                "i"
-            )
-        ))
-    }
+    ?label <bif:contains> ?virtuosoQuery .
 
     OPTIONAL { ?uri rdfs:label ?rdfs_label }
     OPTIONAL { ?uri schema:name ?schema_name }

--- a/packages/network-of-terms-catalog/catalog/queries/search/rkdartists.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/rkdartists.rq
@@ -15,27 +15,8 @@ WHERE {
     ?uri ?name ?label .
     VALUES ?name { schema:name schema:alternateName }
 
-    {
-        FILTER(?virtuosoQuery)
-        ?uri ?predicate ?label .
-        ?label <bif:contains> ?virtuosoQuery .
-    } UNION {
-        # BC support.
-        # The RKD Virtuoso endpoint needs isLiteral() rather than !BOUND() because the latter still matches, throwing an
-        # error for queries with diacritics.
-        FILTER(!isLiteral(?virtuosoQuery))
-
-        ?uri ?predicate ?label .
-        # Replace query "A B" with "A AND B", leaving queries "A AND B" or "A OR B" unchanged.
-        FILTER (<bif:contains> (?label,
-            REPLACE(
-                REPLACE(?query, "[.,]", " "),
-                "(?<!AND)(?<!OR)[[:space:]]+(?!AND)(?!OR)(?!$)(?![[:space:]])",
-                " AND ",
-                "i"
-            )
-        ))
-    }
+    ?uri ?predicate ?label .
+    ?label <bif:contains> ?virtuosoQuery .
 
     OPTIONAL { ?uri schema:name ?schema_name . }
     OPTIONAL { ?uri schema:alternateName ?schema_alternateName . }

--- a/packages/network-of-terms-graphql/README.md
+++ b/packages/network-of-terms-graphql/README.md
@@ -87,8 +87,7 @@ query Sources {
 query {
   terms(
     sources: ["https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht"],
-    query: "fiets",
-    queryMode: OPTIMIZED   # Forwards-compatible query type.
+    query: "fiets"
   ) {
     source {
       uri
@@ -139,8 +138,7 @@ query {
 query {
   terms(
     sources: ["https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql", "http://data.bibliotheken.nl/thesp/sparql"],
-    query: "Gogh",
-    queryMode: OPTIMIZED   # Forwards-compatible query type.
+    query: "Gogh"
   ) {
     source {
       uri

--- a/packages/network-of-terms-graphql/src/schema.ts
+++ b/packages/network-of-terms-graphql/src/schema.ts
@@ -64,7 +64,7 @@ export const schema = `
       query: String!,
 
       "The mode in which the literal search query (\`query\`) is interpreted before it is sent to the term sources."      
-      queryMode: QueryMode = DEPRECATED
+      queryMode: QueryMode = OPTIMIZED
 
       "Timeout period in milliseconds that we wait for sources to respond."
       timeoutMs: Int = 10000
@@ -87,10 +87,7 @@ export const schema = `
   The mode in which the literal search query (\`query\`) is interpreted before it is sent to the term sources.
   """
   enum QueryMode {
-    "This mode is only for backwards-compatibility. Switch to \`OPTIMIZED\` mode for forwards-compatibility."
-    DEPRECATED @deprecated(reason: "This mode will be removed in the future. Use \`OPTIMIZED\` instead.")
-    
-    "Optimize search query input for term sources. This will become the default."
+    "Optimize search query input for term sources. The default."
     OPTIMIZED
     
     "Send the unaltered query input to the term sources. For advanced users that want to have full control over the search query."

--- a/packages/network-of-terms-query/src/search/query-mode.ts
+++ b/packages/network-of-terms-query/src/search/query-mode.ts
@@ -1,7 +1,6 @@
 export enum QueryMode {
   RAW = 'raw',
   OPTIMIZED = 'optimized',
-  DEPRECATED = 'deprecated',
 }
 
 export function queryVariants(query: string, type: QueryMode) {
@@ -16,8 +15,6 @@ export function queryVariants(query: string, type: QueryMode) {
         ['query', stringQuery(query)],
         ['virtuosoQuery', virtuosoQuery(stringQuery(query))],
       ]);
-    case QueryMode.DEPRECATED:
-      return new Map([['query', query]]);
   }
 }
 


### PR DESCRIPTION
BREAKING CHANGE: `queryMode: DEPRECATED` was removed. Default is now
`queryMode: OPTIMIZED`.

Fix #1058
