### PR TITLE
feat: Return term matches

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,9 +11,9 @@ export default {
   ],
   coverageThreshold: {
     global: {
-      lines: 90.95,
-      statements: 90.95,
-      branches: 95.87,
+      lines: 91,
+      statements: 91,
+      branches: 95.93,
       functions: 91.52,
     },
   },

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/aat.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/aat.rq
@@ -17,7 +17,7 @@ CONSTRUCT {
         skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
-    ?exactMatch skos:prefLabel ?exactMatch_prefLabel .
+    ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     # For example:

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/aat.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/aat.rq
@@ -13,9 +13,11 @@ CONSTRUCT {
         skos:scopeNote ?scopeNote ;
         rdfs:seeAlso ?rdfs_seeAlso ;
         skos:broader ?broader_uri ;
-        skos:narrower ?narrower_uri .
+        skos:narrower ?narrower_uri ;
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
+    ?exactMatch skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     # For example:
@@ -50,6 +52,12 @@ WHERE {
         ?narrower_uri skosxl:prefLabel ?narrower_uri_skosxl .
         ?narrower_uri_skosxl dcterms:language aat:300388256 . # Dutch (language)
         ?narrower_uri_skosxl skosxl:literalForm ?narrower_prefLabel .
+    }
+    OPTIONAL {
+        ?uri skos:exactMatch ?exactMatch_uri .
+        ?exactMatch_uri skosxl:prefLabel ?exactMatch_uri_skosxl .
+        ?exactMatch_uri_skosxl dcterms:language aat:300388256 . # Dutch (language)
+        ?exactMatch_uri_skosxl skosxl:literalForm ?exactMatch_prefLabel .
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/adamlink-straten.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/adamlink-straten.rq
@@ -6,7 +6,8 @@ CONSTRUCT {
     ?uri a skos:Concept ;
         skos:prefLabel ?prefLabel ;
         skos:altLabel ?altLabel ;
-        skos:scopeNote ?scopeNote .
+        skos:scopeNote ?scopeNote ;
+        skos:exactMatch ?exactMatch .
 }
 WHERE {
     # For example:
@@ -22,5 +23,6 @@ WHERE {
         ?uri hg:liesIn <http://sws.geonames.org/2759793/> # Gemeente Amsterdam
         BIND("Straat in Gemeente Amsterdam" AS ?scopeNote)
     }
+    OPTIONAL { ?uri owl:sameAs ?exactMatch } # Has no labels.
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/adamlink-straten.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/adamlink-straten.rq
@@ -7,7 +7,7 @@ CONSTRUCT {
         skos:prefLabel ?prefLabel ;
         skos:altLabel ?altLabel ;
         skos:scopeNote ?scopeNote ;
-        skos:exactMatch ?exactMatch .
+        skos:exactMatch ?exactMatch_uri .
 }
 WHERE {
     # For example:
@@ -23,6 +23,6 @@ WHERE {
         ?uri hg:liesIn <http://sws.geonames.org/2759793/> # Gemeente Amsterdam
         BIND("Straat in Gemeente Amsterdam" AS ?scopeNote)
     }
-    OPTIONAL { ?uri owl:sameAs ?exactMatch } # Has no labels.
+    OPTIONAL { ?uri owl:sameAs ?exactMatch_uri } # Has no labels.
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/brinkman-nta-stcn.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/brinkman-nta-stcn.rq
@@ -17,7 +17,7 @@ CONSTRUCT {
         skos:narrower ?narrower_uri ;
         skos:related ?related_uri ;
         skos:inScheme ?datasetUri ;
-        skos:exactMatch ?exactMatch .
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
     ?related_uri skos:prefLabel ?related_prefLabel .
@@ -68,7 +68,7 @@ WHERE {
             ?related_uri skos:prefLabel ?related_prefLabel .
             FILTER(LANG(?related_prefLabel) = "nl")
         }
-        OPTIONAL { ?uri skos:exactMatch ?exactMatch } # Has no labels.
+        OPTIONAL { ?uri skos:exactMatch ?exactMatch_uri } # Has no labels.
     }
 
     # For NTA

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/brinkman-nta-stcn.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/brinkman-nta-stcn.rq
@@ -16,10 +16,12 @@ CONSTRUCT {
         skos:broader ?broader_uri ;
         skos:narrower ?narrower_uri ;
         skos:related ?related_uri ;
-        skos:inScheme ?datasetUri .
+        skos:inScheme ?datasetUri ;
+        skos:exactMatch ?exactMatch .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
     ?related_uri skos:prefLabel ?related_prefLabel .
+    ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     # For example:
@@ -66,6 +68,7 @@ WHERE {
             ?related_uri skos:prefLabel ?related_prefLabel .
             FILTER(LANG(?related_prefLabel) = "nl")
         }
+        OPTIONAL { ?uri skos:exactMatch ?exactMatch } # Has no labels.
     }
 
     # For NTA
@@ -74,11 +77,19 @@ WHERE {
         OPTIONAL { ?uri schema:name ?schema_name }
         OPTIONAL { ?uri schema:alternateName ?schema_alternateName }
         OPTIONAL { ?uri schema:description ?schema_description }
+        OPTIONAL {
+            ?uri ?matchPredicate ?exactMatch_uri .
+            VALUES ?matchPredicate { owl:sameAs schema:sameAs }
+            OPTIONAL {
+                ?exactMatch_uri rdfs:label ?exactMatch_prefLabel .
+            }
+        }
     }
 
     # For STCN
     OPTIONAL {
-        ?uri schema:location/schema:address/schema:addressLocality ?scopeNote
+        OPTIONAL { ?uri schema:location/schema:address/schema:addressLocality ?scopeNote }
+        OPTIONAL { ?uri schema:sameAs ?exactMatch_uri } # Has no labels.
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/eurovoc.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/eurovoc.rq
@@ -7,10 +7,12 @@ CONSTRUCT {
         skos:altLabel ?altLabel ;
         skos:broader ?broader_uri ;
         skos:narrower ?narrower_uri ;
-        skos:related ?related_uri .
+        skos:related ?related_uri ;
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
     ?related_uri skos:prefLabel ?related_prefLabel .
+    ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     #For example:
@@ -41,6 +43,11 @@ WHERE {
         ?uri skos:related ?related_uri .
         ?related_uri skos:prefLabel ?related_prefLabel .
         FILTER(LANG(?related_prefLabel) = "nl")
+    }
+    OPTIONAL {
+        ?uri skos:exactMatch ?exactMatch_uri .
+        ?exactMatch_uri skos:exactMatch ?exactMatch_prefLabel .
+        FILTER(LANG(?exactMatch_prefLabel) = "nl")
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/goudatijdmachine-straten.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/goudatijdmachine-straten.rq
@@ -1,16 +1,18 @@
 PREFIX sdo: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX gtm: <https://www.goudatijdmachine.nl/def#>
-PREFIX schema: <https://schema.org/>
 PREFIX hg: <http://rdf.histograph.io/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
 CONSTRUCT {
     ?uri a skos:Concept ;
          skos:prefLabel ?prefLabel ;
          skos:altLabel ?altLabel ;
          skos:scopeNote ?scopeNote ;
-         skos:related ?related_uri .
+         skos:related ?related_uri ;
+        skos:exactMatch ?exactMatch_uri .
     ?related_uri skos:prefLabel ?related_prefLabel .
+    ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 } WHERE {
     # For example:
     # Vuilsteeg: <https://n2t.net/ark:/60537/bIwfWk>
@@ -29,6 +31,11 @@ CONSTRUCT {
         ?related_uri a gtm:Straat ;
                      sdo:name ?related_prefLabel .
         FILTER (STRSTARTS(STR(?related_uri), "https://n2t.net/ark:/60537/") && ?uri != ?related_uri )
+    }
+
+    OPTIONAL {
+        ?uri owl:sameAs ?exactMatch_uri .
+        ?exactMatch_uri sdo:name ?exactMatch_prefLabel .
     }
 }
 LIMIT 100

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/goudatijdmachine-straten.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/goudatijdmachine-straten.rq
@@ -6,10 +6,10 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
 CONSTRUCT {
     ?uri a skos:Concept ;
-         skos:prefLabel ?prefLabel ;
-         skos:altLabel ?altLabel ;
-         skos:scopeNote ?scopeNote ;
-         skos:related ?related_uri ;
+        skos:prefLabel ?prefLabel ;
+        skos:altLabel ?altLabel ;
+        skos:scopeNote ?scopeNote ;
+        skos:related ?related_uri ;
         skos:exactMatch ?exactMatch_uri .
     ?related_uri skos:prefLabel ?related_prefLabel .
     ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/gtaa.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/gtaa.rq
@@ -9,10 +9,12 @@ CONSTRUCT {
         skos:broader ?broader_uri ;
         skos:narrower ?narrower_uri ;
         skos:related ?related_uri ;
-        skos:inScheme ?datasetUri .
+        skos:inScheme ?datasetUri ;
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
     ?related_uri skos:prefLabel ?related_prefLabel .
+    ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
 
@@ -51,6 +53,11 @@ WHERE {
         ?uri skos:related ?related_uri .
         ?related_uri skos:prefLabel ?related_prefLabel .
         FILTER(LANG(?related_prefLabel) = "nl")
+    }
+    OPTIONAL {
+        ?uri skos:exactMatch ?exactMatch_uri .
+        ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
+        FILTER(LANG(?exactMatch_prefLabel) = "nl")
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/muziekschatten.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/muziekschatten.rq
@@ -1,3 +1,4 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX schema: <http://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX som: <https://data.muziekschatten.nl/som/>
@@ -10,6 +11,7 @@ CONSTRUCT {
         skos:scopeNote ?scopeNote ;
         skos:scopeNote ?schema_hasOccupation ;
         skos:broader ?broader_uri ;
+        skos:exactMatch ?exactMatch_uri ;
         skos:inScheme ?datasetUri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
 }
@@ -48,6 +50,8 @@ WHERE {
             ?broader_uri skos:prefLabel ?broader_prefLabel .
             FILTER(LANG(?broader_prefLabel) = "nl")
         }
+
+        OPTIONAL { ?uri skos:exactMatch ?exactMatch_uri } # Has no labels.
     }
 
     # For subjects
@@ -65,6 +69,9 @@ WHERE {
             ?broader_uri schema:name ?broader_prefLabel .
             FILTER(LANG(?broader_prefLabel) = "nl")
         }
+
+        OPTIONAL { ?uri skos:exactMatch ?exactMatch_uri } # Has no labels.
+
         OPTIONAL {
             ?uri schema:keywords ?schema_keywords
         }
@@ -108,6 +115,7 @@ WHERE {
             ) AS ?dates
         )
         BIND(CONCAT(?name, IF(?dates != "", CONCAT(" (", ?dates, ")"), "")) AS ?prefLabel)
+        OPTIONAL { ?uri owl:sameAs ?exactMatch_uri } # Has no labels.
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/muziekweb.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/muziekweb.rq
@@ -12,7 +12,8 @@ CONSTRUCT {
         skos:scopeNote ?rdfs_comment ;
         skos:scopeNote ?schema_description ;
         skos:broader ?broader_uri ;
-        skos:narrower ?narrower_uri .
+        skos:narrower ?narrower_uri ;
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
 }
@@ -39,5 +40,6 @@ WHERE {
         ?uri skos:narrower ?narrower_uri .
         ?narrower_uri rdfs:label ?narrower_prefLabel
     }
+    OPTIONAL { ?uri owl:sameAs ?exactMatch_uri } # Has no labels.
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/nmvw.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/nmvw.rq
@@ -7,7 +7,8 @@ CONSTRUCT {
         skos:hiddenLabel ?hiddenLabel ;
         skos:scopeNote ?scopeNote ;
         skos:broader ?broader_uri ;
-        skos:narrower ?narrower_uri .
+        skos:narrower ?narrower_uri ;
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
 }
@@ -38,6 +39,9 @@ WHERE {
     OPTIONAL {
         ?uri skos:narrower ?narrower_uri .
         ?narrower_uri skos:prefLabel ?narrower_prefLabel .
+    }
+    OPTIONAL {
+        ?uri skos:exactMatch ?exactMatch_uri . # Has no labels.
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/poolparty.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/poolparty.rq
@@ -8,10 +8,12 @@ CONSTRUCT {
         skos:scopeNote ?scopeNote ;
         skos:broader ?broader_uri ;
         skos:narrower ?narrower_uri ;
-        skos:related ?related_uri .
+        skos:related ?related_uri ;
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
     ?related_uri skos:prefLabel ?related_prefLabel .
+    ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     # For example:
@@ -51,6 +53,13 @@ WHERE {
         ?uri skos:related ?related_uri .
         ?related_uri skos:prefLabel ?related_prefLabel .
         FILTER(LANG(?related_prefLabel) = "nl")
+    }
+    OPTIONAL {
+        ?uri skos:exactMatch ?exactMatch_uri .
+        OPTIONAL {
+            ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
+            FILTER(LANG(?exactMatch_prefLabel) = "nl")
+        }
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/wo2thesaurus.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/wo2thesaurus.rq
@@ -7,7 +7,8 @@ CONSTRUCT {
         skos:hiddenLabel ?hiddenLabel ;
         skos:scopeNote ?scopeNote ;
         skos:broader ?broader_uri ;
-        skos:narrower ?narrower_uri .
+        skos:narrower ?narrower_uri ;
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
 }
@@ -49,6 +50,9 @@ WHERE {
         ?uri skos:narrower ?narrower_uri .
         ?narrower_uri skos:prefLabel ?narrower_prefLabel .
         FILTER(LANG(?narrower_prefLabel) = "nl")
+    }
+    OPTIONAL {
+        ?uri skos:exactMatch ?exactMatch_uri . # Has no labels.
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/aat-materials.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/aat-materials.rq
@@ -15,9 +15,11 @@ CONSTRUCT {
         skos:scopeNote ?scopeNote ;
         rdfs:seeAlso ?rdfs_seeAlso ;
         skos:broader ?broader_uri ;
-        skos:narrower ?narrower_uri .
+        skos:narrower ?narrower_uri ;
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
+    ?exactMatch skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     ?uri luc:term ?query ;
@@ -26,7 +28,7 @@ WHERE {
 
     # limit results to the "materials hierarchy name" (300010357)
     ?uri gvp:broaderPreferred+ <http://vocab.getty.edu/aat/300010357> .
-     
+
     ?type rdfs:subClassOf gvp:Subject .
     FILTER (?type != gvp:Subject) .
     ?uri skosxl:prefLabel ?prefLabel_uri .
@@ -56,6 +58,12 @@ WHERE {
         ?narrower_uri skosxl:prefLabel ?narrower_uri_skosxl .
         ?narrower_uri_skosxl dcterms:language aat:300388256 . # Dutch (language)
         ?narrower_uri_skosxl skosxl:literalForm ?narrower_prefLabel .
+    }
+    OPTIONAL {
+        ?uri skos:exactMatch ?exactMatch_uri .
+        ?exactMatch_uri skosxl:prefLabel ?exactMatch_uri_skosxl .
+        ?exactMatch_uri_skosxl dcterms:language aat:300388256 . # Dutch (language)
+        ?exactMatch_uri_skosxl skosxl:literalForm ?exactMatch_prefLabel .
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/aat-materials.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/aat-materials.rq
@@ -19,7 +19,7 @@ CONSTRUCT {
         skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
-    ?exactMatch skos:prefLabel ?exactMatch_prefLabel .
+    ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     ?uri luc:term ?query ;

--- a/packages/network-of-terms-catalog/catalog/queries/search/aat-processes-and-techniques.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/aat-processes-and-techniques.rq
@@ -19,7 +19,7 @@ CONSTRUCT {
         skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
-    ?exactMatch skos:prefLabel ?exactMatch_prefLabel .
+    ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     ?uri luc:term ?query ;

--- a/packages/network-of-terms-catalog/catalog/queries/search/aat-processes-and-techniques.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/aat-processes-and-techniques.rq
@@ -15,9 +15,11 @@ CONSTRUCT {
         skos:scopeNote ?scopeNote ;
         rdfs:seeAlso ?rdfs_seeAlso ;
         skos:broader ?broader_uri ;
-        skos:narrower ?narrower_uri .
+        skos:narrower ?narrower_uri ;
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
+    ?exactMatch skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     ?uri luc:term ?query ;
@@ -25,8 +27,8 @@ WHERE {
         void:inDataset <http://vocab.getty.edu/dataset/aat>  .
 
     # limit results to the "processes and techniques hierarchy name (300053001)"
-    ?uri gvp:broaderPreferred+ <http://vocab.getty.edu/aat/300053001> . 
-    
+    ?uri gvp:broaderPreferred+ <http://vocab.getty.edu/aat/300053001> .
+
     ?type rdfs:subClassOf gvp:Subject .
     FILTER (?type != gvp:Subject) .
     ?uri skosxl:prefLabel ?prefLabel_uri .
@@ -56,6 +58,12 @@ WHERE {
         ?narrower_uri skosxl:prefLabel ?narrower_uri_skosxl .
         ?narrower_uri_skosxl dcterms:language aat:300388256 . # Dutch (language)
         ?narrower_uri_skosxl skosxl:literalForm ?narrower_prefLabel .
+    }
+    OPTIONAL {
+        ?uri skos:exactMatch ?exactMatch_uri .
+        ?exactMatch_uri skosxl:prefLabel ?exactMatch_uri_skosxl .
+        ?exactMatch_uri_skosxl dcterms:language aat:300388256 . # Dutch (language)
+        ?exactMatch_uri_skosxl skosxl:literalForm ?exactMatch_prefLabel .
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/aat-styles-and-periods.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/aat-styles-and-periods.rq
@@ -19,7 +19,7 @@ CONSTRUCT {
         skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
-    ?exactMatch skos:prefLabel ?exactMatch_prefLabel .
+    ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     ?uri luc:term ?query ;

--- a/packages/network-of-terms-catalog/catalog/queries/search/aat-styles-and-periods.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/aat-styles-and-periods.rq
@@ -15,18 +15,20 @@ CONSTRUCT {
         skos:scopeNote ?scopeNote ;
         rdfs:seeAlso ?rdfs_seeAlso ;
         skos:broader ?broader_uri ;
-        skos:narrower ?narrower_uri .
+        skos:narrower ?narrower_uri ;
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
+    ?exactMatch skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     ?uri luc:term ?query ;
         a ?type ;
         void:inDataset <http://vocab.getty.edu/dataset/aat>  .
-    
-    # limit results to the "styles and periodes hierarchy name (300015646)" 
-    ?uri gvp:broaderPreferred+ <http://vocab.getty.edu/aat/300015646> . 
-    
+
+    # limit results to the "styles and periodes hierarchy name (300015646)"
+    ?uri gvp:broaderPreferred+ <http://vocab.getty.edu/aat/300015646> .
+
     ?type rdfs:subClassOf gvp:Subject .
     FILTER (?type != gvp:Subject) .
     ?uri skosxl:prefLabel ?prefLabel_uri .
@@ -56,6 +58,12 @@ WHERE {
         ?narrower_uri skosxl:prefLabel ?narrower_uri_skosxl .
         ?narrower_uri_skosxl dcterms:language aat:300388256 . # Dutch (language)
         ?narrower_uri_skosxl skosxl:literalForm ?narrower_prefLabel .
+    }
+    OPTIONAL {
+        ?uri skos:exactMatch ?exactMatch_uri .
+        ?exactMatch_uri skosxl:prefLabel ?exactMatch_uri_skosxl .
+        ?exactMatch_uri_skosxl dcterms:language aat:300388256 . # Dutch (language)
+        ?exactMatch_uri_skosxl skosxl:literalForm ?exactMatch_prefLabel .
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/aat.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/aat.rq
@@ -15,9 +15,11 @@ CONSTRUCT {
         skos:scopeNote ?scopeNote ;
         rdfs:seeAlso ?rdfs_seeAlso ;
         skos:broader ?broader_uri ;
-        skos:narrower ?narrower_uri .
+        skos:narrower ?narrower_uri ;
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
+    ?exactMatch skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     ?uri luc:term ?query ;
@@ -52,6 +54,12 @@ WHERE {
         ?narrower_uri skosxl:prefLabel ?narrower_uri_skosxl .
         ?narrower_uri_skosxl dcterms:language aat:300388256 . # Dutch (language)
         ?narrower_uri_skosxl skosxl:literalForm ?narrower_prefLabel .
+    }
+    OPTIONAL {
+        ?uri skos:exactMatch ?exactMatch_uri .
+        ?exactMatch_uri skosxl:prefLabel ?exactMatch_uri_skosxl .
+        ?exactMatch_uri_skosxl dcterms:language aat:300388256 . # Dutch (language)
+        ?exactMatch_uri_skosxl skosxl:literalForm ?exactMatch_prefLabel .
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/aat.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/aat.rq
@@ -19,7 +19,7 @@ CONSTRUCT {
         skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
-    ?exactMatch skos:prefLabel ?exactMatch_prefLabel .
+    ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     ?uri luc:term ?query ;

--- a/packages/network-of-terms-catalog/catalog/queries/search/adamlink-straten.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/adamlink-straten.rq
@@ -1,4 +1,5 @@
 PREFIX hg: <http://rdf.histograph.io/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX void: <http://rdfs.org/ns/void#>
 
@@ -6,7 +7,8 @@ CONSTRUCT {
     ?uri a skos:Concept ;
         skos:prefLabel ?prefLabel ;
         skos:altLabel ?altLabel ;
-        skos:scopeNote ?scopeNote .
+        skos:scopeNote ?scopeNote ;
+        skos:exactMatch ?exactMatch .
 }
 WHERE {
     ?uri void:inDataset <https://data.adamlink.nl/adamnet/geography/> .
@@ -21,5 +23,6 @@ WHERE {
         ?uri hg:liesIn <http://sws.geonames.org/2759793/> # Gemeente Amsterdam
         BIND("Straat in Gemeente Amsterdam" AS ?scopeNote)
     }
+    OPTIONAL { ?uri owl:sameAs ?exactMatch } # Has no labels.
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/adamlink-straten.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/adamlink-straten.rq
@@ -8,7 +8,7 @@ CONSTRUCT {
         skos:prefLabel ?prefLabel ;
         skos:altLabel ?altLabel ;
         skos:scopeNote ?scopeNote ;
-        skos:exactMatch ?exactMatch .
+        skos:exactMatch ?exactMatch_uri .
 }
 WHERE {
     ?uri void:inDataset <https://data.adamlink.nl/adamnet/geography/> .
@@ -23,6 +23,6 @@ WHERE {
         ?uri hg:liesIn <http://sws.geonames.org/2759793/> # Gemeente Amsterdam
         BIND("Straat in Gemeente Amsterdam" AS ?scopeNote)
     }
-    OPTIONAL { ?uri owl:sameAs ?exactMatch } # Has no labels.
+    OPTIONAL { ?uri owl:sameAs ?exactMatch_uri } # Has no labels.
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/brinkman.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/brinkman.rq
@@ -54,6 +54,6 @@ WHERE {
         ?related_uri skos:prefLabel ?related_prefLabel .
         FILTER(LANG(?related_prefLabel) = "nl")
     }
-    OPTIONAL { ?uri skos:exactMatch ?exactMatch }
+    OPTIONAL { ?uri skos:exactMatch ?exactMatch } # Has no labels.
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/brinkman.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/brinkman.rq
@@ -10,7 +10,7 @@ CONSTRUCT {
         skos:broader ?broader_uri ;
         skos:narrower ?narrower_uri ;
         skos:related ?related_uri ;
-        skos:exactMatch ?exactMatch .
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
     ?related_uri skos:prefLabel ?related_prefLabel .
@@ -54,6 +54,6 @@ WHERE {
         ?related_uri skos:prefLabel ?related_prefLabel .
         FILTER(LANG(?related_prefLabel) = "nl")
     }
-    OPTIONAL { ?uri skos:exactMatch ?exactMatch } # Has no labels.
+    OPTIONAL { ?uri skos:exactMatch ?exactMatch_uri } # Has no labels.
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/cht-materials.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/cht-materials.rq
@@ -8,10 +8,12 @@ CONSTRUCT {
         skos:scopeNote ?scopeNote ;
         skos:broader ?broader_uri ;
         skos:narrower ?narrower_uri ;
-        skos:related ?related_uri .
+        skos:related ?related_uri ;
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
     ?related_uri skos:prefLabel ?related_prefLabel .
+    ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     ?uri ?predicate ?label .
@@ -19,7 +21,7 @@ WHERE {
 
     # limit results to the narrower terms of the toplevel term 'materialen'
     ?uri skos:broader+ <https://data.cultureelerfgoed.nl/term/id/cht/aa872ce6-a74c-4f81-96ec-6ee0e717f92a> .
-    
+
     FILTER(LANG(?label) = "nl")
     FILTER(CONTAINS(LCASE(?label), LCASE(?query)))
     OPTIONAL {
@@ -52,6 +54,13 @@ WHERE {
         ?uri skos:related ?related_uri .
         ?related_uri skos:prefLabel ?related_prefLabel .
         FILTER(LANG(?related_prefLabel) = "nl")
+    }
+    OPTIONAL {
+        ?uri skos:exactMatch ?exactMatch_uri .
+        OPTIONAL {
+            ?exactMatch_uri skos:prefLabel ?exactMatch_label .
+            FILTER(LANG(?exactMatch_label) = "nl")
+        }
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/cht-materials.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/cht-materials.rq
@@ -58,8 +58,8 @@ WHERE {
     OPTIONAL {
         ?uri skos:exactMatch ?exactMatch_uri .
         OPTIONAL {
-            ?exactMatch_uri skos:prefLabel ?exactMatch_label .
-            FILTER(LANG(?exactMatch_label) = "nl")
+            ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
+            FILTER(LANG(?exactMatch_prefLabel) = "nl")
         }
     }
 }

--- a/packages/network-of-terms-catalog/catalog/queries/search/cht-styles-and-periods.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/cht-styles-and-periods.rq
@@ -8,10 +8,12 @@ CONSTRUCT {
         skos:scopeNote ?scopeNote ;
         skos:broader ?broader_uri ;
         skos:narrower ?narrower_uri ;
-        skos:related ?related_uri .
+        skos:related ?related_uri ;
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
     ?related_uri skos:prefLabel ?related_prefLabel .
+    ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     ?uri ?predicate ?label .
@@ -19,7 +21,7 @@ WHERE {
 
     # limit results to the narrower terms of the toplevel term 'stijlen en periodes'
     ?uri skos:broader+ <https://data.cultureelerfgoed.nl/term/id/cht/63cca950-f545-467a-9d70-db3a2b21bba3> .
-    
+
     FILTER(LANG(?label) = "nl")
     FILTER(CONTAINS(LCASE(?label), LCASE(?query)))
     OPTIONAL {
@@ -52,6 +54,13 @@ WHERE {
         ?uri skos:related ?related_uri .
         ?related_uri skos:prefLabel ?related_prefLabel .
         FILTER(LANG(?related_prefLabel) = "nl")
+    }
+    OPTIONAL {
+        ?uri skos:exactMatch ?exactMatch_uri .
+        OPTIONAL {
+            ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
+            FILTER(LANG(?exactMatch_label) = "nl")
+        }
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/cht-styles-and-periods.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/cht-styles-and-periods.rq
@@ -59,7 +59,7 @@ WHERE {
         ?uri skos:exactMatch ?exactMatch_uri .
         OPTIONAL {
             ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
-            FILTER(LANG(?exactMatch_label) = "nl")
+            FILTER(LANG(?exactMatch_prefLabel) = "nl")
         }
     }
 }

--- a/packages/network-of-terms-catalog/catalog/queries/search/eurovoc.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/eurovoc.rq
@@ -7,10 +7,12 @@ CONSTRUCT {
         skos:altLabel ?altLabel ;
         skos:broader ?broader_uri ;
         skos:narrower ?narrower_uri ;
-        skos:related ?related_uri .
+        skos:related ?related_uri ;
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
-    ?related_uri skos:prefLabel ?related_prefLabel . 
+    ?related_uri skos:prefLabel ?related_prefLabel .
+    ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     ?uri a eurovoc:ThesaurusConcept .
@@ -19,7 +21,7 @@ WHERE {
     FILTER(LANG(?label) = "nl")
     # The http://publications.europa.eu/webapi/rdf/sparql endpoint
     # is based on Virtuoso but it looks like fulltext search support
-    # is not enabled therefore fallback to the standard CONTAINS function 
+    # is not enabled therefore fallback to the standard CONTAINS function
     FILTER (CONTAINS(LCASE(STR(?label)),LCASE(?query)))
     OPTIONAL {
         ?uri skos:prefLabel ?prefLabel .
@@ -43,6 +45,11 @@ WHERE {
         ?uri skos:related ?related_uri .
         ?related_uri skos:prefLabel ?related_prefLabel .
         FILTER(LANG(?related_prefLabel) = "nl")
+    }
+    OPTIONAL {
+        ?uri skos:exactMatch ?exactMatch_uri .
+        ?exactMatch_uri skos:exactMatch ?exactMatch_prefLabel .
+        FILTER(LANG(?exactMatch_prefLabel) = "nl")
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/goudatijdmachine-straten.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/goudatijdmachine-straten.rq
@@ -5,21 +5,24 @@ PREFIX hg: <http://rdf.histograph.io/>
 PREFIX luc: <http://www.ontotext.com/connectors/lucene#>
 PREFIX luc-index: <http://www.ontotext.com/connectors/lucene/instance#>
 PREFIX omeka: <http://omeka.org/s/vocabs/o#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
 CONSTRUCT {
     ?uri a skos:Concept ;
         skos:prefLabel ?prefLabel ;
         skos:altLabel ?altLabel;
         skos:scopeNote ?scopeNote ;
-        skos:related ?related_uri .
+        skos:related ?related_uri ;
+        skos:exactMatch ?exactMatch_uri .
     ?related_uri skos:prefLabel ?related_prefLabel .
+    ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 } WHERE {
     ?search a luc-index:straten_index ;
         luc:query ?query ;
         luc:entities ?uri .
 
     FILTER (STRSTARTS(STR(?uri), "https://n2t.net/ark:/60537/"))
-       
+
     ?uri sdo:name ?prefLabel ;
         luc:score ?score .
 
@@ -27,13 +30,13 @@ CONSTRUCT {
         ?uri gtm:genoemdNaar ?genoemdNaar .
     }
 
-    BIND ( 
-        CONCAT( 
+    BIND (
+        CONCAT(
             IF ( EXISTS { ?entity omeka:item_set <https://n2t.net/ark:/60537/bd75pg> }, "Verdwenen straat", "Straat" ),
             IF ( BOUND(?genoemdNaar), CONCAT(" in Gouda, genoemd naar ", ?genoemdNaar )," in Gouda" )
-        ) 
+        )
     AS ?scopeNote )
-    
+
     OPTIONAL { ?uri sdo:alternateName ?altLabel . }
 
     OPTIONAL {
@@ -41,5 +44,10 @@ CONSTRUCT {
         ?related_uri a gtm:Straat ;
             sdo:name ?related_prefLabel .
         FILTER (STRSTARTS(STR(?related_uri), "https://n2t.net/ark:/60537/") && ?uri != ?related_uri )
+    }
+
+    OPTIONAL {
+        ?uri owl:sameAs ?exactMatch_uri .
+        ?exactMatch_uri sdo:name ?exactMatch_prefLabel .
     }
 } ORDER BY DESC(?score) LIMIT 100

--- a/packages/network-of-terms-catalog/catalog/queries/search/gtaa.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/gtaa.rq
@@ -12,10 +12,12 @@ CONSTRUCT {
         skos:broader ?broader_uri ;
         skos:narrower ?narrower_uri ;
         skos:related ?related_uri ;
+        skos:exactMatch ?exactMatch_uri ;
         vrank:simpleRank ?score .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
     ?related_uri skos:prefLabel ?related_prefLabel .
+    ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     (?uri ?score) text:query (skos:prefLabel skos:altLabel skos:hiddenLabel ?query) .
@@ -53,6 +55,11 @@ WHERE {
         ?uri skos:related ?related_uri .
         ?related_uri skos:prefLabel ?related_prefLabel .
         FILTER(LANG(?related_prefLabel) = "nl")
+    }
+    OPTIONAL {
+        ?uri skos:exactMatch ?exactMatch_uri .
+        ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
+        FILTER(LANG(?exactMatch_prefLabel) = "nl")
     }
 }
 ORDER BY DESC(?score)

--- a/packages/network-of-terms-catalog/catalog/queries/search/muziekschatten-onderwerpen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/muziekschatten-onderwerpen.rq
@@ -1,3 +1,4 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX schema: <http://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX som: <https://data.muziekschatten.nl/som/>
@@ -6,7 +7,8 @@ CONSTRUCT {
     ?uri a skos:Concept;
         skos:prefLabel ?schema_name;
         skos:scopeNote ?scopeNote;
-        skos:broader ?broader_uri .
+        skos:broader ?broader_uri ;
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_schema_name .
 }
 WHERE {
@@ -40,5 +42,6 @@ WHERE {
     )
 
     ?uri som:BASIS "1" .
+    OPTIONAL { ?uri skos:exactMatch ?exactMatch_uri } # Has no labels.
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/muziekschatten-personen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/muziekschatten-personen.rq
@@ -1,3 +1,4 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX schema: <http://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX som: <https://data.muziekschatten.nl/som/>
@@ -24,7 +25,8 @@ CONSTRUCT {
     ?uri a skos:Concept;
         skos:prefLabel ?prefLabel ;
         skos:altLabel ?schema_alternateName ;
-        skos:scopeNote ?schema_hasOccupation .
+        skos:scopeNote ?schema_hasOccupation ;
+        skos:exactMatch ?exactMatch_uri .
 }
 WHERE {
     ?uri a schema:Person .
@@ -59,5 +61,6 @@ WHERE {
         ) AS ?dates
     )
     BIND(CONCAT(?name, IF(?dates != "", CONCAT(" (", ?dates, ")"), "")) AS ?prefLabel)
+    OPTIONAL { ?uri owl:sameAs ?exactMatch_uri } # Has no labels.
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/mw-genresstijlen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/mw-genresstijlen.rq
@@ -1,14 +1,16 @@
 PREFIX muziekweb: <https://data.muziekweb.nl/vocab/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
 CONSTRUCT {
     ?uri a skos:Concept ;
         skos:prefLabel ?rdfs_label ;
-        skos:scopeNote ?rdfs_comment .
-    ?uri skos:broader ?broader_uri .
+        skos:scopeNote ?rdfs_comment ;
+        skos:broader ?broader_uri ;
+        skos:narrower ?narrower_uri ;
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
-    ?uri skos:narrower ?narrower_uri .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
 }
 WHERE {
@@ -25,5 +27,6 @@ WHERE {
         ?narrower_uri rdfs:label ?narrower_prefLabel
     }
     OPTIONAL { ?uri rdfs:comment ?rdfs_comment }
+    OPTIONAL { ?uri owl:sameAs ?exactMatch_uri } # Has no labels.
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/mw-personengroepen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/mw-personengroepen.rq
@@ -1,3 +1,4 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX schema: <http://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
@@ -7,7 +8,8 @@ CONSTRUCT {
         skos:prefLabel ?prefLabel ;
         skos:altLabel ?altLabel ;
         skos:hiddenLabel ?hiddenLabel ;
-        skos:scopeNote ?schema_description .
+        skos:scopeNote ?schema_description ;
+        skos:exactMatch ?exactMatch_uri .
 }
 WHERE {
     ?uri a schema:MusicGroup ;
@@ -19,5 +21,6 @@ WHERE {
     OPTIONAL { ?uri skos:altLabel ?altLabel }
     OPTIONAL { ?uri skos:hiddenLabel ?hiddenLabel }
     OPTIONAL { ?uri schema:description ?schema_description }
+    OPTIONAL { ?uri owl:sameAs ?exactMatch_uri } # Has no labels.
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/nmvw.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/nmvw.rq
@@ -5,10 +5,11 @@ CONSTRUCT {
         skos:prefLabel ?prefLabel ;
         skos:altLabel ?altLabel ;
         skos:hiddenLabel ?hiddenLabel ;
-        skos:scopeNote ?scopeNote .
-    ?uri skos:broader ?broader_uri .
+        skos:scopeNote ?scopeNote ;
+        skos:broader ?broader_uri ;
+        skos:narrower ?narrower_uri ;
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
-    ?uri skos:narrower ?narrower_uri .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
 }
 WHERE {
@@ -35,6 +36,9 @@ WHERE {
     OPTIONAL {
         ?uri skos:narrower ?narrower_uri .
         ?narrower_uri skos:prefLabel ?narrower_prefLabel .
+    }
+    OPTIONAL {
+        ?uri skos:exactMatch ?exactMatch_uri . # Has no labels.
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/nta.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/nta.rq
@@ -1,11 +1,16 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX schema: <http://schema.org/>
 
 CONSTRUCT {
     ?uri a skos:Concept ;
         skos:prefLabel ?rdfs_label ;
         skos:altLabel ?schema_name ;
         skos:altLabel ?schema_alternateName ;
-        skos:scopeNote ?schema_description .
+        skos:scopeNote ?schema_description ;
+        skos:exactMatch ?exactMatch_uri .
+    ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     ?uri schema:mainEntityOfPage/schema:isPartOf <http://data.bibliotheken.nl/id/dataset/persons> ;
@@ -17,5 +22,12 @@ WHERE {
     OPTIONAL { ?uri schema:name ?schema_name }
     OPTIONAL { ?uri schema:alternateName ?schema_alternateName }
     OPTIONAL { ?uri schema:description ?schema_description }
+    OPTIONAL {
+        ?uri ?matchPredicate ?exactMatch_uri .
+        VALUES ?matchPredicate { owl:sameAs schema:sameAs }
+        OPTIONAL {
+            ?exactMatch_uri rdfs:label ?exactMatch_prefLabel .
+        }
+    }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/poolparty.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/poolparty.rq
@@ -8,10 +8,12 @@ CONSTRUCT {
         skos:scopeNote ?scopeNote ;
         skos:broader ?broader_uri ;
         skos:narrower ?narrower_uri ;
-        skos:related ?related_uri .
+        skos:related ?related_uri ;
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
     ?related_uri skos:prefLabel ?related_prefLabel .
+    ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     ?uri ?predicate ?label .
@@ -48,6 +50,13 @@ WHERE {
         ?uri skos:related ?related_uri .
         ?related_uri skos:prefLabel ?related_prefLabel .
         FILTER(LANG(?related_prefLabel) = "nl")
+    }
+    OPTIONAL {
+        ?uri skos:exactMatch ?exactMatch_uri .
+        OPTIONAL {
+            ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
+            FILTER(LANG(?exactMatch_prefLabel) = "nl")
+        }
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/stcn-drukkers.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/stcn-drukkers.rq
@@ -8,7 +8,8 @@ CONSTRUCT {
         skos:prefLabel ?rdfs_label ;
         skos:altLabel ?schema_name ;
         skos:altLabel ?schema_alternateName ;
-        skos:scopeNote ?scopeNote .
+        skos:scopeNote ?scopeNote ;
+        skos:exactMatch ?exactMatch_uri .
 }
 WHERE {
     ?uri schema:mainEntityOfPage/schema:isPartOf <http://data.bibliotheken.nl/id/dataset/stcn/printers> ;
@@ -24,10 +25,13 @@ WHERE {
     # http://data.bibliotheken.nl/id/thes/p075556251 for Plantijn working in Leiden
     # http://data.bibliotheken.nl/id/thes/p338012834 for Plantijn working in Antwerp
     # The original source (STCN) shows also a time period, this data currently not available in the LOD version.
-    OPTIONAL { 
-     ?uri schema:location/schema:address/schema:addressLocality ?scopeNote 
+    OPTIONAL {
+     ?uri schema:location/schema:address/schema:addressLocality ?scopeNote
     }
     OPTIONAL { ?uri schema:name ?schema_name }
     OPTIONAL { ?uri schema:alternateName ?schema_alternateName }
+    OPTIONAL {
+        ?uri schema:sameAs ?exactMatch_uri . # Has no labels.
+    }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/uitvoeringsmedium.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/uitvoeringsmedium.rq
@@ -6,7 +6,8 @@ CONSTRUCT {
         skos:prefLabel ?prefLabel ;
         skos:altLabel ?altLabel ;
         skos:scopeNote ?scopeNote ;
-        skos:broader ?broader_uri .
+        skos:broader ?broader_uri ;
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
 }
 WHERE {
@@ -34,5 +35,7 @@ WHERE {
         ?broader_uri skos:prefLabel ?broader_prefLabel .
         FILTER(LANG(?broader_prefLabel) = "nl")
     }
+
+    OPTIONAL { ?uri skos:exactMatch ?exactMatch_uri } # Has no labels.
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/wikidata-entities-persons.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/wikidata-entities-persons.rq
@@ -1,5 +1,6 @@
 PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX mwapi: <https://www.mediawiki.org/ontology#API/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX schema: <http://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX wikibase: <http://wikiba.se/ontology#>

--- a/packages/network-of-terms-catalog/catalog/queries/search/wikidata-entities-places.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/wikidata-entities-places.rq
@@ -1,5 +1,6 @@
 PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX mwapi: <https://www.mediawiki.org/ontology#API/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX schema: <http://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX wikibase: <http://wikiba.se/ontology#>

--- a/packages/network-of-terms-catalog/catalog/queries/search/wo2thesaurus.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/wo2thesaurus.rq
@@ -7,7 +7,8 @@ CONSTRUCT {
         skos:hiddenLabel ?hiddenLabel ;
         skos:scopeNote ?scopeNote ;
         skos:broader ?broader_uri ;
-        skos:narrower ?narrower_uri .
+        skos:narrower ?narrower_uri ;
+        skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
 }
@@ -45,6 +46,9 @@ WHERE {
         ?uri skos:narrower ?narrower_uri .
         ?narrower_uri skos:prefLabel ?narrower_prefLabel .
         FILTER(LANG(?narrower_prefLabel) = "nl")
+    }
+    OPTIONAL {
+        ?uri skos:exactMatch ?exactMatch_uri . # Has no labels.
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-graphql/README.md
+++ b/packages/network-of-terms-graphql/README.md
@@ -121,6 +121,10 @@ query {
             uri
             prefLabel
           }
+          exactMatch {
+            uri
+            prefLabel
+          }
         }
       }
       ... on Error {
@@ -205,6 +209,10 @@ query {
         scopeNote
         seeAlso
         broader {
+          uri
+          prefLabel
+        }
+        exactMatch {
           uri
           prefLabel
         }

--- a/packages/network-of-terms-graphql/src/resolvers.ts
+++ b/packages/network-of-terms-graphql/src/resolvers.ts
@@ -131,6 +131,10 @@ function term(term: Term) {
       uri: related.id.value,
       prefLabel: related.prefLabels.map(prefLabel => prefLabel.value),
     })),
+    exactMatch: term.exactMatches.map(exactMatch => ({
+      uri: exactMatch.id.value,
+      prefLabel: exactMatch.prefLabels.map(prefLabel => prefLabel.value)
+    })),
   };
 }
 

--- a/packages/network-of-terms-graphql/src/resolvers.ts
+++ b/packages/network-of-terms-graphql/src/resolvers.ts
@@ -133,7 +133,7 @@ function term(term: Term) {
     })),
     exactMatch: term.exactMatches.map(exactMatch => ({
       uri: exactMatch.id.value,
-      prefLabel: exactMatch.prefLabels.map(prefLabel => prefLabel.value)
+      prefLabel: exactMatch.prefLabels.map(prefLabel => prefLabel.value),
     })),
   };
 }

--- a/packages/network-of-terms-graphql/src/schema.ts
+++ b/packages/network-of-terms-graphql/src/schema.ts
@@ -51,6 +51,7 @@ export const schema = `
     broader: [RelatedTerm]
     narrower: [RelatedTerm]
     related: [RelatedTerm]
+    exactMatch: [RelatedTerm]
   }
 
   type RelatedTerm {

--- a/packages/network-of-terms-graphql/test/server.test.ts
+++ b/packages/network-of-terms-graphql/test/server.test.ts
@@ -105,6 +105,12 @@ describe('Server', () => {
     expect(artwork.description).toEqual([
       'One of the most famous Dutch paintings',
     ]);
+    expect(artwork.exactMatch).toEqual([
+      {
+        prefLabel: ['Exact match'],
+        uri: 'https://example.com/resources/match'
+      }
+    ]);
 
     const prefLabels = body.data.terms[0].result.terms.map(
       ({prefLabel}: {prefLabel: string[]}) => prefLabel[0] ?? ''
@@ -242,6 +248,10 @@ function termsQuery(sources: string[], query = 'nachtwacht') {
               related {
                 uri
                 prefLabel
+              }
+              exactMatch {
+                uri
+                prefLabel 
               }
             }
           }

--- a/packages/network-of-terms-graphql/test/server.test.ts
+++ b/packages/network-of-terms-graphql/test/server.test.ts
@@ -108,8 +108,8 @@ describe('Server', () => {
     expect(artwork.exactMatch).toEqual([
       {
         prefLabel: ['Exact match'],
-        uri: 'https://example.com/resources/match'
-      }
+        uri: 'https://example.com/resources/match',
+      },
     ]);
 
     const prefLabels = body.data.terms[0].result.terms.map(

--- a/packages/network-of-terms-query/src/server-test.ts
+++ b/packages/network-of-terms-query/src/server-test.ts
@@ -49,6 +49,10 @@ export const testCatalog = (port: number) =>
               ?labelPredicate ?label .
             VALUES ?labelPredicate { skos:prefLabel skos:altLabel skos:hiddenLabel }
             FILTER (regex(?label, ?query, "i"))
+            OPTIONAL { 
+              ?s skos:exactMatch ?match .
+              ?match skos:prefLabel ?match_label .
+            }
           }`,
           `
           PREFIX skos: <http://www.w3.org/2004/02/skos/core#>

--- a/packages/network-of-terms-query/src/terms.ts
+++ b/packages/network-of-terms-query/src/terms.ts
@@ -12,6 +12,7 @@ export class Term {
     readonly broaderTerms: RelatedTerm[],
     readonly narrowerTerms: RelatedTerm[],
     readonly relatedTerms: RelatedTerm[],
+    readonly exactMatches: RelatedTerm[],
     readonly datasetIri: RDF.Term | undefined,
     readonly score: RDF.Literal | undefined
   ) {}
@@ -35,6 +36,7 @@ class SparqlResultTerm {
   broaderTerms: RDF.Term[] = [];
   narrowerTerms: RDF.Term[] = [];
   relatedTerms: RDF.Term[] = [];
+  exactMatches: RDF.Term[] = [];
   inScheme: RDF.Term | undefined = undefined;
   score: RDF.Literal | undefined = undefined;
 }
@@ -59,6 +61,8 @@ export class TermsTransformer {
     ['http://www.w3.org/2008/05/skos#narrower', 'narrowerTerms'],
     ['http://www.w3.org/2004/02/skos/core#related', 'relatedTerms'],
     ['http://www.w3.org/2008/05/skos#related', 'relatedTerms'],
+    ['http://www.w3.org/2004/02/skos/core#exactMatch', 'exactMatches'],
+    ['http://www.w3.org/2008/05/skos#exactMatch', 'exactMatches'],
     ['http://www.w3.org/2004/02/skos/core#inScheme', 'inScheme'],
     ['http://purl.org/voc/vrank#simpleRank', 'score'],
   ]);
@@ -109,6 +113,7 @@ export class TermsTransformer {
           alphabeticallyByPrefLabel
         ),
         this.mapRelatedTerms(term.relatedTerms).sort(alphabeticallyByPrefLabel),
+        this.mapRelatedTerms(term.exactMatches).sort(alphabeticallyByPrefLabel),
         term.inScheme,
         term.score
       );
@@ -124,9 +129,7 @@ export class TermsTransformer {
   private mapRelatedTerms = (terms: RDF.Term[]) =>
     terms.reduce((acc: RelatedTerm[], iri: RDF.Term) => {
       const term = this.termsMap.get(iri.value);
-      if (term) {
-        acc.push(new RelatedTerm(term.id, term.prefLabels));
-      }
+      acc.push(new RelatedTerm(iri, term?.prefLabels ?? []));
       return acc;
     }, []);
 }

--- a/packages/network-of-terms-query/test/fixtures/terms.ttl
+++ b/packages/network-of-terms-query/test/fixtures/terms.ttl
@@ -12,6 +12,7 @@
     skos:related <https://example.com/resources/painter> ,
         <https://example.com/resources/painting> ,
         <https://example.com/resources/art> ;
+    skos:exactMatch <https://example.com/resources/match> ;
     skos:ignored "Not used by Network of Terms" ;
     rdfs:seeAlso <https://example.com/html/artwork> ;
     vrank:simpleRank 18.0 .
@@ -38,3 +39,6 @@
 <https://example.com/resources/alphabet>
     a skos:Concept ;
     skos:altLabel "Resource without prefLabel" .
+
+<https://example.com/resources/match>
+    skos:prefLabel "Exact match" .

--- a/packages/network-of-terms-reconciliation/src/preview.ts
+++ b/packages/network-of-terms-reconciliation/src/preview.ts
@@ -53,12 +53,13 @@ const literal = (values: Literal[]) =>
   values.map(literal => literal.value).join(' • ');
 
 function relatedTerms(label: string, terms: RelatedTerm[]) {
-  if (terms.length === 0) {
+  const termsWithPrefLabel = terms.filter(term => term.prefLabels.length > 0);
+  if (termsWithPrefLabel.length === 0) {
     return '';
   }
 
   return `<dt>${label}</dt>
       <dd>${escapeHtml(
-        terms.map(term => term.prefLabels[0].value).join(' • ')
+        termsWithPrefLabel.map(term => term.prefLabels[0].value).join(' • ')
       )}</dd>`;
 }


### PR DESCRIPTION
* Add `exactMatch` to GraphQL output.
* Return exact matches (and other related terms) even if the source
  has no label for them.

Fix #895