### PR TITLE
fix: AAT exactMatch has no labels

### DIFF
--- a/packages/network-of-terms-catalog/catalog/queries/lookup/aat.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/aat.rq
@@ -17,7 +17,6 @@ CONSTRUCT {
         skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
-    ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     # For example:
@@ -54,10 +53,8 @@ WHERE {
         ?narrower_uri_skosxl skosxl:literalForm ?narrower_prefLabel .
     }
     OPTIONAL {
-        ?uri skos:exactMatch ?exactMatch_uri .
-        ?exactMatch_uri skosxl:prefLabel ?exactMatch_uri_skosxl .
-        ?exactMatch_uri_skosxl dcterms:language aat:300388256 . # Dutch (language)
-        ?exactMatch_uri_skosxl skosxl:literalForm ?exactMatch_prefLabel .
+        ?uri skos:exactMatch ?exactMatch_uri . # Has no labels.
+        FILTER(?exactMatch_uri != ?uri) # Exclude self-reference.
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/aat-materials.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/aat-materials.rq
@@ -60,10 +60,8 @@ WHERE {
         ?narrower_uri_skosxl skosxl:literalForm ?narrower_prefLabel .
     }
     OPTIONAL {
-        ?uri skos:exactMatch ?exactMatch_uri .
-        ?exactMatch_uri skosxl:prefLabel ?exactMatch_uri_skosxl .
-        ?exactMatch_uri_skosxl dcterms:language aat:300388256 . # Dutch (language)
-        ?exactMatch_uri_skosxl skosxl:literalForm ?exactMatch_prefLabel .
+        ?uri skos:exactMatch ?exactMatch_uri . # Has no labels.
+        FILTER(?exactMatch_uri != ?uri) # Exclude self-reference.
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/aat-processes-and-techniques.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/aat-processes-and-techniques.rq
@@ -19,7 +19,6 @@ CONSTRUCT {
         skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
-    ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     ?uri luc:term ?query ;
@@ -60,10 +59,8 @@ WHERE {
         ?narrower_uri_skosxl skosxl:literalForm ?narrower_prefLabel .
     }
     OPTIONAL {
-        ?uri skos:exactMatch ?exactMatch_uri .
-        ?exactMatch_uri skosxl:prefLabel ?exactMatch_uri_skosxl .
-        ?exactMatch_uri_skosxl dcterms:language aat:300388256 . # Dutch (language)
-        ?exactMatch_uri_skosxl skosxl:literalForm ?exactMatch_prefLabel .
+        ?uri skos:exactMatch ?exactMatch_uri . # Has no labels.
+        FILTER(?exactMatch_uri != ?uri) # Exclude self-reference.
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/aat-styles-and-periods.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/aat-styles-and-periods.rq
@@ -19,7 +19,6 @@ CONSTRUCT {
         skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
-    ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
     ?uri luc:term ?query ;
@@ -60,10 +59,8 @@ WHERE {
         ?narrower_uri_skosxl skosxl:literalForm ?narrower_prefLabel .
     }
     OPTIONAL {
-        ?uri skos:exactMatch ?exactMatch_uri .
-        ?exactMatch_uri skosxl:prefLabel ?exactMatch_uri_skosxl .
-        ?exactMatch_uri_skosxl dcterms:language aat:300388256 . # Dutch (language)
-        ?exactMatch_uri_skosxl skosxl:literalForm ?exactMatch_prefLabel .
+        ?uri skos:exactMatch ?exactMatch_uri . # Has no labels.
+        FILTER(?exactMatch_uri != ?uri) # Exclude self-reference.
     }
 }
 LIMIT 1000


### PR DESCRIPTION
* Support exactMatches without label.
* Filter out self-references.