### PR TITLE
feat: Exclude RCE referentienetwerk matches from CHT

### DIFF
--- a/packages/network-of-terms-catalog/catalog/datasets/cht.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/cht.jsonld
@@ -41,11 +41,11 @@
       "potentialAction": [
         {
           "@type": "SearchAction",
-          "query": "file://catalog/queries/search/poolparty.rq"
+          "query": "file://catalog/queries/search/cht.rq"
         },
         {
           "@type": "FindAction",
-          "query": "file://catalog/queries/lookup/poolparty.rq"
+          "query": "file://catalog/queries/lookup/cht.rq"
         },
         {
           "@type": "Action",

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/cht.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/cht.rq
@@ -16,14 +16,13 @@ CONSTRUCT {
     ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
-    ?uri ?predicate ?label .
-    VALUES ?predicate { skos:prefLabel skos:altLabel }
+    # For example:
+    # Aardewerk: <https://data.cultureelerfgoed.nl/term/id/abr/71e411bf-8645-4420-98a4-b8746574b002>
+    # Aardewerk: <https://data.cultureelerfgoed.nl/term/id/cht/dfbf8107-09f9-49c9-8118-8e79b7613723>
+    VALUES ?uri { ?uris }
 
-    # limit results to the narrower terms of the toplevel term 'materialen'
-    ?uri skos:broader+ <https://data.cultureelerfgoed.nl/term/id/cht/aa872ce6-a74c-4f81-96ec-6ee0e717f92a> .
+    ?uri a skos:Concept .
 
-    FILTER(LANG(?label) = "nl")
-    FILTER(CONTAINS(LCASE(?label), LCASE(?query)))
     OPTIONAL {
         ?uri skos:prefLabel ?prefLabel .
         FILTER(LANG(?prefLabel) = "nl")

--- a/packages/network-of-terms-catalog/catalog/queries/search/cht-styles-and-periods.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/cht-styles-and-periods.rq
@@ -57,6 +57,7 @@ WHERE {
     }
     OPTIONAL {
         ?uri skos:exactMatch ?exactMatch_uri .
+        FILTER(!STRSTARTS(STR(?exactMatch_uri), "https://data.cultureelerfgoed.nl/term/id/rn"))
         OPTIONAL {
             ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
             FILTER(LANG(?exactMatch_prefLabel) = "nl")

--- a/packages/network-of-terms-catalog/catalog/queries/search/cht.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/cht.rq
@@ -18,10 +18,6 @@ CONSTRUCT {
 WHERE {
     ?uri ?predicate ?label .
     VALUES ?predicate { skos:prefLabel skos:altLabel }
-
-    # limit results to the narrower terms of the toplevel term 'materialen'
-    ?uri skos:broader+ <https://data.cultureelerfgoed.nl/term/id/cht/aa872ce6-a74c-4f81-96ec-6ee0e717f92a> .
-
     FILTER(LANG(?label) = "nl")
     FILTER(CONTAINS(LCASE(?label), LCASE(?query)))
     OPTIONAL {


### PR DESCRIPTION
* Duplicate generate PoolParty queries to make CHT-specific changes.