### PR TITLE
Update and add Adamlink resources

### DIFF
--- a/packages/network-of-terms-catalog/catalog/datasets/adamlink-adressen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/adamlink-adressen.jsonld
@@ -1,0 +1,58 @@
+{
+  "@context": "https://schema.org/docs/jsonldcontext.jsonld",
+  "@id": "https://adamlink.nl/geo/addresses/start/",
+  "@type": "Dataset",
+  "name": [
+    {
+      "@language": "nl",
+      "@value": "Adamlink: Historische adressen in Amsterdam"
+    }
+  ],
+  "creator": [
+    {
+      "@id": "https://www.amsterdamtimemachine.nl"
+    }
+  ],
+  "url": [
+    "https://adamlink.nl/geo/address/"
+  ],
+  "mainEntityOfPage": [
+    "https://adamlink.nl"
+  ],
+  "description": [
+    {
+      "@language": "nl",
+      "@value": "Historische adressen in Amsterdam"
+    }
+  ],
+  "inLanguage": "nl",
+  "distribution": [
+    {
+      "@id": "https://api.lod.uba.uva.nl/datasets/ATM/ATM-KG/services/ATM-KG/sparql#adamlink-addresses",
+      "@type": "DataDownload",
+      "contentUrl": "https://api.lod.uba.uva.nl/datasets/ATM/ATM-KG/services/ATM-KG/sparql",
+      "encodingFormat": "application/sparql-query",
+      "potentialAction": [
+        {
+          "@type": "SearchAction",
+          "query": "file://catalog/queries/search/adamlink-adressen.rq"
+        },
+        {
+          "@type": "FindAction",
+          "query": "file://catalog/queries/lookup/adamlink-adressen.rq"
+        },
+        {
+          "@type": "Action",
+          "target": {
+            "@type": "EntryPoint",
+            "actionApplication": {
+              "@id": "https://reconciliation-api.github.io/specs/latest/",
+              "@type": "SoftwareApplication"
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/network-of-terms-catalog/catalog/datasets/adamlink-adressen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/adamlink-adressen.jsonld
@@ -5,7 +5,7 @@
   "name": [
     {
       "@language": "nl",
-      "@value": "Adamlink: Historische adressen in Amsterdam"
+      "@value": "Adamlink: historische adressen in Amsterdam"
     }
   ],
   "creator": [

--- a/packages/network-of-terms-catalog/catalog/datasets/adamlink-straten.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/adamlink-straten.jsonld
@@ -10,7 +10,7 @@
   ],
   "creator": [
     {
-      "@id": "https://www.adamnet.nl"
+      "@id": "https://www.amsterdamtimemachine.nl"
     }
   ],
   "url": [
@@ -28,9 +28,9 @@
   "inLanguage": "nl",
   "distribution": [
     {
-      "@id": "https://druid.datalegend.net/AdamNet/Geography/sparql#streets",
+      "@id": "https://api.lod.uba.uva.nl/datasets/ATM/ATM-KG/services/ATM-KG/sparql#adamlink-streets",
       "@type": "DataDownload",
-      "contentUrl": "https://api.druid.datalegend.net/datasets/AdamNet/Geography/services/endpoint/sparql",
+      "contentUrl": "https://api.lod.uba.uva.nl/datasets/ATM/ATM-KG/services/ATM-KG/sparql",
       "encodingFormat": "application/sparql-query",
       "potentialAction": [
         {

--- a/packages/network-of-terms-catalog/catalog/publishers.jsonld
+++ b/packages/network-of-terms-catalog/catalog/publishers.jsonld
@@ -108,6 +108,12 @@
       "@type": "Organization",
       "name": "Podiumkunst.net",
       "alternateName": "Podiumkunst.net"
+    },
+    {
+      "@id": "https://www.amsterdamtimemachine.nl",
+      "@type": "Organization",
+      "name": "Amsterdam Time Machine",
+      "alternateName": "ATM"
     }
   ]
 }

--- a/packages/network-of-terms-catalog/catalog/publishers.jsonld
+++ b/packages/network-of-terms-catalog/catalog/publishers.jsonld
@@ -68,12 +68,6 @@
       "alternateName": "Europese Unie"
     },
     {
-      "@id": "https://www.adamnet.nl",
-      "@type": "Organization",
-      "name": "Stichting AdamNet",
-      "alternateName": "AdamNet"
-    },
-    {
       "@id": "https://www.erfgoedbrabant.nl",
       "@type": "Organization",
       "name": "Erfgoed Brabant",

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/adamlink-adressen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/adamlink-adressen.rq
@@ -1,0 +1,49 @@
+PREFIX hg: <http://rdf.histograph.io/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX roar: <https://w3id.org/roar#>
+PREFIX schema: <https://schema.org/>
+PREFIX bag: <http://bag.basisregistraties.overheid.nl/def/bag#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+CONSTRUCT {
+    ?uri a skos:Concept ;
+        skos:prefLabel ?prefLabel ;
+        skos:altLabel ?altLabel ;
+        skos:scopeNote ?scopeNote ;
+        skos:exactMatch ?exactMatch_uri ;
+        rdfs:seeAlso ?seeAlso_uri .
+
+    ?seeAlso_uri skos:prefLabel ?seeAlso_label .
+}
+WHERE {
+    # For example:
+    # Jodenbreestraat: <https://adamlink.nl/geo/street/jodenbreestraat/2158>
+    # Damrak: <https://adamlink.nl/geo/street/damrak/882>
+  
+    VALUES ?uri { ?uris }
+  
+    GRAPH <https://lod.uba.uva.nl/ATM/Adamlink/graphs/addresses> {
+        ?uri a hg:Address .
+  
+        OPTIONAL { ?uri rdfs:label ?prefLabel }
+        OPTIONAL { ?uri skos:altLabel ?altLabel }
+        OPTIONAL {
+            ?uri roar:documentedIn ?source .
+            ?source rdfs:label ?source_name .
+            BIND(CONCAT("Adres afkomstig van ", ?source_name) AS ?scopeNote)
+        }
+        OPTIONAL { ?uri owl:sameAs ?exactMatch_uri } # Has no labels.
+        OPTIONAL { 
+            ?exactMatch_uri a bag:Pand ;
+                            schema:geoContains ?geo .
+            ?uri schema:geoContains ?geo . 
+        } # A historical address is very similar to a bag:Pand
+        OPTIONAL {
+            ?uri schema:geoContains ?geo .
+            ?seeAlso_uri schema:geoContains ?geo ;
+                      skos:altLabel ?seeAlso_label .
+        }
+    }
+}
+LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/adamlink-straten.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/adamlink-straten.rq
@@ -1,6 +1,6 @@
 PREFIX hg: <http://rdf.histograph.io/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-PREFIX void: <http://rdfs.org/ns/void#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
 CONSTRUCT {
     ?uri a skos:Concept ;
@@ -13,16 +13,19 @@ WHERE {
     # For example:
     # Jodenbreestraat: <https://adamlink.nl/geo/street/jodenbreestraat/2158>
     # Damrak: <https://adamlink.nl/geo/street/damrak/882>
+  
     VALUES ?uri { ?uris }
-
-    ?uri a hg:Street .
-
-    OPTIONAL { ?uri skos:prefLabel ?prefLabel }
-    OPTIONAL { ?uri skos:altLabel ?altLabel }
-    OPTIONAL {
-        ?uri hg:liesIn <http://sws.geonames.org/2759793/> # Gemeente Amsterdam
-        BIND("Straat in Gemeente Amsterdam" AS ?scopeNote)
+  
+    GRAPH <https://lod.uba.uva.nl/ATM/Adamlink/graphs/streets> {
+        ?uri a hg:Street .
+    
+        OPTIONAL { ?uri skos:prefLabel ?prefLabel }
+        OPTIONAL { ?uri skos:altLabel ?altLabel }
+        OPTIONAL {
+            ?uri hg:liesIn <http://sws.geonames.org/2759793/> # Gemeente Amsterdam
+            BIND("Straat in Gemeente Amsterdam" AS ?scopeNote)
+        }
+        OPTIONAL { ?uri owl:sameAs ?exactMatch_uri } # Has no labels.
     }
-    OPTIONAL { ?uri owl:sameAs ?exactMatch_uri } # Has no labels.
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/adamlink-adressen.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/adamlink-adressen.rq
@@ -1,0 +1,49 @@
+PREFIX hg: <http://rdf.histograph.io/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX bif: <http://www.openlinksw.com/schemas/bif#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX roar: <https://w3id.org/roar#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX bag: <http://bag.basisregistraties.overheid.nl/def/bag#>
+PREFIX schema: <https://schema.org/>
+
+CONSTRUCT {
+    ?uri a skos:Concept ;
+        skos:prefLabel ?prefLabel ;
+        skos:altLabel ?altLabel ;
+        skos:scopeNote ?scopeNote ;
+        skos:exactMatch ?exactMatch_uri ;
+        rdfs:seeAlso ?seeAlso_uri .
+
+    ?seeAlso_uri skos:prefLabel ?seeAlso_label .
+}
+WHERE {
+    GRAPH <https://lod.uba.uva.nl/ATM/Adamlink/graphs/addresses> {
+        ?uri a hg:Address .
+        ?uri ?predicate ?label .
+
+        VALUES ?predicate { rdfs:label skos:prefLabel skos:altLabel }
+
+        ?label <bif:contains> ?virtuosoQuery .
+
+        OPTIONAL { ?uri rdfs:label ?prefLabel }
+        OPTIONAL { ?uri skos:altLabel ?altLabel }
+        OPTIONAL {
+            ?uri roar:documentedIn ?source .
+            ?source rdfs:label ?source_name .
+            BIND(CONCAT("Adres afkomstig van ", ?source_name) AS ?scopeNote)
+        }
+        OPTIONAL { ?uri owl:sameAs ?exactMatch_uri }
+        OPTIONAL { 
+            ?exactMatch_uri a bag:Pand ;
+                            schema:geoContains ?geo .
+            ?uri schema:geoContains ?geo . 
+        } # A historical address is very similar to a bag:Pand
+        OPTIONAL {
+            ?uri schema:geoContains ?geo .
+            ?seeAlso_uri schema:geoContains ?geo ;
+                      skos:altLabel ?seeAlso_label .
+        }
+    }
+}
+LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/adamlink-straten.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/adamlink-straten.rq
@@ -1,7 +1,7 @@
 PREFIX hg: <http://rdf.histograph.io/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX bif: <http://www.openlinksw.com/schemas/bif#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-PREFIX void: <http://rdfs.org/ns/void#>
 
 CONSTRUCT {
     ?uri a skos:Concept ;
@@ -11,18 +11,21 @@ CONSTRUCT {
         skos:exactMatch ?exactMatch_uri .
 }
 WHERE {
-    ?uri void:inDataset <https://data.adamlink.nl/adamnet/geography/> .
-    ?uri a hg:Street .
-    ?uri ?predicate ?label .
-    VALUES ?predicate { skos:prefLabel skos:altLabel }
-    ?label <bif:contains> ?virtuosoQuery .
+    GRAPH <https://lod.uba.uva.nl/ATM/Adamlink/graphs/streets> {
+        ?uri a hg:Street .
+        ?uri ?predicate ?label .
 
-    OPTIONAL { ?uri skos:prefLabel ?prefLabel }
-    OPTIONAL { ?uri skos:altLabel ?altLabel }
-    OPTIONAL {
-        ?uri hg:liesIn <http://sws.geonames.org/2759793/> # Gemeente Amsterdam
-        BIND("Straat in Gemeente Amsterdam" AS ?scopeNote)
+        VALUES ?predicate { skos:prefLabel skos:altLabel }
+
+        ?label <bif:contains> ?virtuosoQuery .
+
+        OPTIONAL { ?uri skos:prefLabel ?prefLabel }
+        OPTIONAL { ?uri skos:altLabel ?altLabel }
+        OPTIONAL {
+            ?uri hg:liesIn <http://sws.geonames.org/2759793/> # Gemeente Amsterdam
+            BIND("Straat in Gemeente Amsterdam" AS ?scopeNote)
+        }
+        OPTIONAL { ?uri owl:sameAs ?exactMatch_uri } # Has no labels.
     }
-    OPTIONAL { ?uri owl:sameAs ?exactMatch_uri } # Has no labels.
 }
 LIMIT 1000


### PR DESCRIPTION
This PR:
1. Updates the Adamlink Streets dataset to the latest version hosted at https://lod.uba.uva.nl/ATM/Adamlink.
2. Adds the Adamlink Historical Addresses as separate dataset. 

The search and lookup queries for both datasets use the generic Amsterdam Time Machine Knowledge Graph endpoint at https://api.lod.uba.uva.nl/datasets/ATM/ATM-KG/services/ATM-KG/sparql (Virtuoso). 