### PR TITLE
remove deprecated semnet uri's

### DIFF
--- a/packages/network-of-terms-catalog/catalog/queries/lookup/cht.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/cht.rq
@@ -57,6 +57,7 @@ WHERE {
     OPTIONAL {
         ?uri skos:exactMatch ?exactMatch_uri .
         FILTER(!STRSTARTS(STR(?exactMatch_uri), "https://data.cultureelerfgoed.nl/term/id/rn"))
+        FILTER(!STRSTARTS(STR(?exactMatch_uri), "https://data.cultureelerfgoed.nl/semnet"))
         OPTIONAL {
             ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
             FILTER(LANG(?exactMatch_prefLabel) = "nl")

--- a/packages/network-of-terms-catalog/catalog/queries/search/cht-materials.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/cht-materials.rq
@@ -58,6 +58,7 @@ WHERE {
     OPTIONAL {
         ?uri skos:exactMatch ?exactMatch_uri .
         FILTER(!STRSTARTS(STR(?exactMatch_uri), "https://data.cultureelerfgoed.nl/term/id/rn"))
+        FILTER(!STRSTARTS(STR(?exactMatch_uri), "https://data.cultureelerfgoed.nl/semnet"))
         OPTIONAL {
             ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
             FILTER(LANG(?exactMatch_prefLabel) = "nl")

--- a/packages/network-of-terms-catalog/catalog/queries/search/cht-styles-and-periods.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/cht-styles-and-periods.rq
@@ -58,6 +58,7 @@ WHERE {
     OPTIONAL {
         ?uri skos:exactMatch ?exactMatch_uri .
         FILTER(!STRSTARTS(STR(?exactMatch_uri), "https://data.cultureelerfgoed.nl/term/id/rn"))
+        FILTER(!STRSTARTS(STR(?exactMatch_uri), "https://data.cultureelerfgoed.nl/semnet"))
         OPTIONAL {
             ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
             FILTER(LANG(?exactMatch_prefLabel) = "nl")

--- a/packages/network-of-terms-catalog/catalog/queries/search/cht.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/cht.rq
@@ -54,6 +54,7 @@ WHERE {
     OPTIONAL {
         ?uri skos:exactMatch ?exactMatch_uri .
         FILTER(!STRSTARTS(STR(?exactMatch_uri), "https://data.cultureelerfgoed.nl/term/id/rn"))
+        FILTER(!STRSTARTS(STR(?exactMatch_uri), "https://data.cultureelerfgoed.nl/semnet"))
         OPTIONAL {
             ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
             FILTER(LANG(?exactMatch_prefLabel) = "nl")


### PR DESCRIPTION
Remove deprecated semnet uri's from exactMatch search and lookup queries for cht