### PR TITLE
Update of Rijksmonumenten dataset and queries

### DIFF
--- a/packages/network-of-terms-catalog/catalog/datasets/rijksmonumenten.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/rijksmonumenten.jsonld
@@ -35,7 +35,7 @@
     {
       "@id": "https://linkeddata.cultureelerfgoed.nl/cho-kennis/id/rijksmonument/",
       "@type": "DataDownload",
-      "contentUrl": "https://api.linkeddata.cultureelerfgoed.nl/datasets/rce/Rijksmonument/services/Rijksmonument/sparql",
+      "contentUrl": "https://api.linkeddata.cultureelerfgoed.nl/datasets/rce/cho/services/cho/sparql",
       "encodingFormat": "application/sparql-query",
       "potentialAction": [
         {

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/rijksmonumenten.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/rijksmonumenten.rq
@@ -1,47 +1,62 @@
-PREFIX ceo: <https://linkeddata.cultureelerfgoed.nl/def/ceo/>
+PREFIX ceo: <https://linkeddata.cultureelerfgoed.nl/def/ceo#>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX ceosp: <https://linkeddata.cultureelerfgoed.nl/def/ceosp/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 
 CONSTRUCT {
-    ?uri a skos:Concept ;
+    ?monument_uri a skos:Concept ;
         skos:prefLabel ?rijksmonumentnummer_tn ;
         skos:altLabel ?adres;
         skos:scopeNote ?scopeNote ;
         rdfs:seeAlso ?rdfs_seeAlso .
 }
 WHERE {
-    VALUES ?uri { ?uris }
-    ?uri ceo:rijksmonumentnummer ?rijksmonumentnummer .
-    OPTIONAL { ?uri ceosp:naam ?naam }
-    OPTIONAL { ?uri ceosp:volledigAdres ?adres_zoeken }
-    OPTIONAL { ?uri ceosp:postcode ?postcode1 }
-    OPTIONAL { ?uri ceosp:heeftGemeente ?woonplaats }
-    OPTIONAL { ?uri ceosp:oorspronkelijkeFunctie ?functie }
-    OPTIONAL { ?uri ceosp:redengevendeOmschrijving ?redengevende_omschrijving }
-    OPTIONAL { ?uri ceo:isOnderdeelVanComplex/ceo:heeftHoofdobject/ceo:rijksmonumentnummer ?rijksmonumentnummer_hoofdobject }
+    VALUES ?monument_uri {?uris  }
+  
+  
 
+    ?monument_uri ceo:rijksmonumentnummer ?rijksmonumentnummer .
+  ?monument_uri a ceo:Rijksmonument .
+    OPTIONAL { ?monument_uri ceo:heeftNaam/ceo:naam ?naam } .
+    OPTIONAL { ?monument_uri ceo:heeftBasisregistratieRelatie/ceo:heeftGemeente/skos:prefLabel ?woonplaats }
+    OPTIONAL { ?monument_uri ceo:heeftOorspronkelijkeFunctie/ceo:heeftFunctieNaam/skos:prefLabel ?functie }
+    OPTIONAL { ?monument_uri ceo:heeftOmschrijving ?redengevende_omschrijving .
+      ?redengevende_omschrijving ceo:omschrijving ?omschrijving_label .
+    ?redengevende_omschrijving ceo:formeelStandpunt "1"^^xsd:boolean .}
+    OPTIONAL { ?monument_uri ceo:isOnderdeelVanComplex/ceo:heeftHoofdobject/ceo:rijksmonumentnummer ?rijksmonumentnummer_hoofdobject }
+    OPTIONAL { ?monument_uri ceo:heeftBasisregistratieRelatie/ceo:heeftBAGRelatie/ceo:volledigAdres ?adres1 }
+    
+ BIND(CONCAT(
+        IF(BOUND(?woonplaats), CONCAT(?woonplaats, " "), ""),
+        IF(BOUND(?omschrijving_label), CONCAT(?omschrijving_label, " "), ""),
+     IF(BOUND(?adres1), CONCAT(?adres1, " "), "")
+    ) AS ?combinedLabels)
+
+
+  
     BIND(URI(CONCAT("https://monumentenregister.cultureelerfgoed.nl/monumenten/", ?rijksmonumentnummer)) as ?rdfs_seeAlso)
-    BIND(STRAFTER(STR(?woonplaats), "owms/terms/") AS ?owms_string)
     BIND(CONCAT("Rijksmonumentnummer ", ?rijksmonumentnummer) as ?rijksmonumentnummer_tn)
     BIND(
-        CONCAT(
-            IF(BOUND(?woonplaats), CONCAT(" ",?owms_string, ", "), ""),
+        CONCAT(?rijksmonumentnummer_tn,",",
+            IF(BOUND(?woonplaats), CONCAT(" ",?woonplaats, ", "), ""),
             IF(BOUND(?functie), CONCAT("Oorspronkelijke functie: ", ?functie), ""),
-            IF(BOUND(?naam), CONCAT(", Naam: ", ?naam), ""),
+           IF(BOUND(?naam), CONCAT(", Naam: ", ?naam), ""),
             IF(BOUND(?rijksmonumentnummer_hoofdobject) && ?rijksmonumentnummer != ?rijksmonumentnummer_hoofdobject,
                 CONCAT(", Rijksmonumentnummer van hoofdobject: ", ?rijksmonumentnummer_hoofdobject),
-            ""
+              ""
             )
-        ) as ?scopeNote
-    )
+        ) as ?scopeNote)
+    
+  
+  
     {
-        SELECT ?uri (MIN(?optional_altlabel) AS ?adres) WHERE {
-            ?uri ceo:rijksmonumentnummer ?rijksmonumentnummer .
-            OPTIONAL { ?uri ceosp:volledigAdres ?adres1 }
+        SELECT ?monument_uri  (MIN(?optional_altlabel) AS ?adres) WHERE {
+            ?monument_uri ceo:rijksmonumentnummer ?rijksmonumentnummer .
+           OPTIONAL { ?monument_uri ceo:heeftBasisregistratieRelatie/ceo:heeftBAGRelatie/ceo:volledigAdres ?adres1 }
             BIND(IF(BOUND(?adres1), ?adres1, "Geen adres beschikbaar") AS ?optional_altlabel)
         }
+        GROUP BY ?monument_uri
     }
-}
-LIMIT 1000
+  } LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/rijksmonumenten.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/rijksmonumenten.rq
@@ -1,49 +1,64 @@
-PREFIX ceo: <https://linkeddata.cultureelerfgoed.nl/def/ceo/>
+PREFIX ceo: <https://linkeddata.cultureelerfgoed.nl/def/ceo#>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX ceosp: <https://linkeddata.cultureelerfgoed.nl/def/ceosp/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 
 CONSTRUCT {
+
     ?monument_uri a skos:Concept ;
         skos:prefLabel ?rijksmonumentnummer_tn ;
         skos:altLabel ?adres ;
         skos:scopeNote ?scopeNote ;
         rdfs:seeAlso ?rdfs_seeAlso .
-}
-WHERE {
-    ?monument_uri ?predicate ?label .
-    VALUES ?predicate { ceo:rijksmonumentnummer ceosp:naam ceosp:volledigAdres ceosp:postcode ceosp:woonplaatsnaam ceosp:redengevendeOmschrijving ceosp:heeftGemeente ceosp:oorspronkelijkeFunctie }
-
-    ?label <bif:contains> ?virtuosoQuery .
+} 
+  
+  
+  WHERE {
+    
+   FILTER(CONTAINS(LCASE(?combinedLabels), LCASE(?query)))
 
     ?monument_uri ceo:rijksmonumentnummer ?rijksmonumentnummer .
-    OPTIONAL { ?monument_uri ceosp:naam ?naam }
-    OPTIONAL { ?monument_uri ceosp:heeftGemeente ?woonplaats }
-    OPTIONAL { ?monument_uri ceosp:oorspronkelijkeFunctie ?functie }
-    OPTIONAL { ?monument_uri ceosp:redengevendeOmschrijving ?redengevende_omschrijving }
+  ?monument_uri a ceo:Rijksmonument .
+    OPTIONAL { ?monument_uri ceo:heeftNaam/ceo:naam ?naam } .
+    OPTIONAL { ?monument_uri ceo:heeftBasisregistratieRelatie/ceo:heeftGemeente/skos:prefLabel ?woonplaats }
+    OPTIONAL { ?monument_uri ceo:heeftOorspronkelijkeFunctie/ceo:heeftFunctieNaam/skos:prefLabel ?functie }
+    OPTIONAL { ?monument_uri ceo:heeftOmschrijving ?redengevende_omschrijving .
+      ?redengevende_omschrijving ceo:omschrijving ?omschrijving_label .
+    ?redengevende_omschrijving ceo:formeelStandpunt "1"^^xsd:boolean .}
     OPTIONAL { ?monument_uri ceo:isOnderdeelVanComplex/ceo:heeftHoofdobject/ceo:rijksmonumentnummer ?rijksmonumentnummer_hoofdobject }
+    OPTIONAL { ?monument_uri ceo:heeftBasisregistratieRelatie/ceo:heeftBAGRelatie/ceo:volledigAdres ?adres1 }
+    
+ BIND(CONCAT(
+        IF(BOUND(?woonplaats), CONCAT(?woonplaats, " "), ""),
+        IF(BOUND(?omschrijving_label), CONCAT(?omschrijving_label, " "), ""),
+     IF(BOUND(?adres1), CONCAT(?adres1, " "), "")
+    ) AS ?combinedLabels)
 
+
+  
     BIND(URI(CONCAT("https://monumentenregister.cultureelerfgoed.nl/monumenten/", ?rijksmonumentnummer)) as ?rdfs_seeAlso)
-    BIND(STRAFTER(STR(?woonplaats), "owms/terms/") AS ?owms_string)
     BIND(CONCAT("Rijksmonumentnummer ", ?rijksmonumentnummer) as ?rijksmonumentnummer_tn)
     BIND(
-        CONCAT(
-            IF(BOUND(?woonplaats), CONCAT(" ",?owms_string, ", "), ""),
+        CONCAT(?rijksmonumentnummer_tn,",",
+            IF(BOUND(?woonplaats), CONCAT(" ",?woonplaats, ", "), ""),
             IF(BOUND(?functie), CONCAT("Oorspronkelijke functie: ", ?functie), ""),
-            IF(BOUND(?naam), CONCAT(", Naam: ", ?naam), ""),
+           IF(BOUND(?naam), CONCAT(", Naam: ", ?naam), ""),
             IF(BOUND(?rijksmonumentnummer_hoofdobject) && ?rijksmonumentnummer != ?rijksmonumentnummer_hoofdobject,
                 CONCAT(", Rijksmonumentnummer van hoofdobject: ", ?rijksmonumentnummer_hoofdobject),
               ""
             )
-        ) as ?scopeNote
-    )
+        ) as ?scopeNote)
+    
+  
+  
     {
-        SELECT ?monument_uri (MIN(?optional_altlabel) AS ?adres) WHERE {
+        SELECT ?monument_uri  (MIN(?optional_altlabel) AS ?adres) WHERE {
             ?monument_uri ceo:rijksmonumentnummer ?rijksmonumentnummer .
-            OPTIONAL { ?monument_uri ceosp:volledigAdres ?adres1 }
+           OPTIONAL { ?monument_uri ceo:heeftBasisregistratieRelatie/ceo:heeftBAGRelatie/ceo:volledigAdres ?adres1 }
             BIND(IF(BOUND(?adres1), ?adres1, "Geen adres beschikbaar") AS ?optional_altlabel)
         }
         GROUP BY ?monument_uri
     }
-  }
+  } LIMIT 1000


### PR DESCRIPTION
RCE Rijksmonumenten now uses the CHO dataset (more stable and up-to-date). Endpoint is changed and queries as well, since CHO uses a different datamodel.