### PR TITLE
Added missing prefix and replaced non-existing ?entity to fix search & lookup of goudatijdmachine-straten

### DIFF
--- a/packages/network-of-terms-catalog/catalog/queries/lookup/goudatijdmachine-straten.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/goudatijdmachine-straten.rq
@@ -3,6 +3,7 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX gtm: <https://www.goudatijdmachine.nl/def#>
 PREFIX hg: <http://rdf.histograph.io/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX omeka: <http://omeka.org/s/vocabs/o#>
 
 CONSTRUCT {
     ?uri a skos:Concept ;
@@ -25,7 +26,7 @@ CONSTRUCT {
     OPTIONAL {
         ?uri sdo:alternateName ?altLabel
     }
-    BIND ( CONCAT( IF ( EXISTS { ?entity omeka:item_set <https://n2t.net/ark:/60537/bd75pg> }, "Verdwenen straat", "Straat" )," in Gouda") AS ?scopeNote )
+    BIND ( CONCAT( IF ( EXISTS { ?uri omeka:item_set <https://n2t.net/ark:/60537/bd75pg> }, "Verdwenen straat", "Straat" )," in Gouda") AS ?scopeNote )
     OPTIONAL {
         ?uri hg:absorbedBy|hg:absorbed ?related_uri .
         ?related_uri a gtm:Straat ;

--- a/packages/network-of-terms-catalog/catalog/queries/search/goudatijdmachine-straten.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/goudatijdmachine-straten.rq
@@ -7,7 +7,6 @@ PREFIX luc-index: <http://www.ontotext.com/connectors/lucene/instance#>
 PREFIX omeka: <http://omeka.org/s/vocabs/o#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX o: <http://omeka.org/s/vocabs/o#>
 
 CONSTRUCT {
     ?piduri a skos:Concept ;
@@ -36,7 +35,7 @@ CONSTRUCT {
 
     BIND (
         CONCAT(
-            IF ( EXISTS { ?entity omeka:item_set <https://n2t.net/ark:/60537/bd75pg> }, "Verdwenen straat", "Straat" ),
+            IF ( EXISTS { ?uri omeka:item_set <https://n2t.net/ark:/60537/bd75pg> }, "Verdwenen straat", "Straat" ),
             IF ( BOUND(?genoemdNaar), CONCAT(" in Gouda, genoemd naar ", ?genoemdNaar )," in Gouda" )
         )
     AS ?scopeNote )
@@ -52,6 +51,6 @@ CONSTRUCT {
 
     OPTIONAL {
         ?uri rdfs:seeAlso ?exactMatch_uri .
-        ?exactMatch_uri o:label ?exactMatch_label .
+        ?exactMatch_uri omeka:label ?exactMatch_label .
     }
 } ORDER BY DESC(?score) LIMIT 100


### PR DESCRIPTION
Fix for [#1424](https://github.com/netwerk-digitaal-erfgoed/network-of-terms/issues/1424)

Strange that these SPARQL errors weren't noticed by the NoT software.