### PR TITLE
feat: Identify datasets by their URI

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,7 @@ export default {
     global: {
       lines: 91.4,
       statements: 91.4,
-      branches: 95.45,
+      branches: 95.46,
       functions: 92.62,
     },
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,10 +10,10 @@ export default {
   ],
   coverageThreshold: {
     global: {
-      lines: 91.37,
-      statements: 91.37,
-      branches: 95.08,
-      functions: 92.56,
+      lines: 91.39,
+      statements: 91.39,
+      branches: 95.45,
+      functions: 92.62,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,8 +10,8 @@ export default {
   ],
   coverageThreshold: {
     global: {
-      lines: 91.39,
-      statements: 91.39,
+      lines: 91.4,
+      statements: 91.4,
       branches: 95.45,
       functions: 92.62,
     },

--- a/packages/network-of-terms-catalog/catalog/datasets/aat-materials.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/aat-materials.jsonld
@@ -60,7 +60,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/aat-materials.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/aat-materials.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org/docs/jsonldcontext.jsonld",
-  "@id": "http://vocab.getty.edu/aat/materials",
+  "@id": "http://vocab.getty.edu/aat#materials",
   "@type": "Dataset",
   "name": [
     {

--- a/packages/network-of-terms-catalog/catalog/datasets/aat-processes-and-techniques.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/aat-processes-and-techniques.jsonld
@@ -60,7 +60,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/aat-processes-and-techniques.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/aat-processes-and-techniques.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org/docs/jsonldcontext.jsonld",
-  "@id": "http://vocab.getty.edu/aat/processes-and-techniques",
+  "@id": "http://vocab.getty.edu/aat#processes-and-techniques",
   "@type": "Dataset",
   "name": [
     {

--- a/packages/network-of-terms-catalog/catalog/datasets/aat-styles-and-periods.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/aat-styles-and-periods.jsonld
@@ -63,7 +63,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/aat-styles-and-periods.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/aat-styles-and-periods.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org/docs/jsonldcontext.jsonld",
-  "@id": "http://vocab.getty.edu/aat/styles-and-periods",
+  "@id": "http://vocab.getty.edu/aat#styles-and-periods",
   "@type": "Dataset",
   "name": [
     {
@@ -20,7 +20,7 @@
     },
     {
       "@id": "https://data.cultureelerfgoed.nl/termennetwerk/onderwerpen/Stijlen"
-    }    
+    }
   ],
   "creator": [
     {

--- a/packages/network-of-terms-catalog/catalog/datasets/aat.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/aat.jsonld
@@ -81,7 +81,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/abr.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/abr.jsonld
@@ -72,7 +72,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/adamlink-adressen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/adamlink-adressen.jsonld
@@ -54,7 +54,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/adamlink-straten.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/adamlink-straten.jsonld
@@ -54,7 +54,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/brabantse-gebouwen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/brabantse-gebouwen.jsonld
@@ -54,7 +54,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/brinkman.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/brinkman.jsonld
@@ -60,7 +60,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/cht-materials.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/cht-materials.jsonld
@@ -60,7 +60,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/cht-materials.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/cht-materials.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org/docs/jsonldcontext.jsonld",
-  "@id": "https://data.cultureelerfgoed.nl/term/id/cht/materials",
+  "@id": "https://data.cultureelerfgoed.nl/term/id/cht#materials",
   "@type": "Dataset",
   "name": [
     {

--- a/packages/network-of-terms-catalog/catalog/datasets/cht-styles-and-periods.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/cht-styles-and-periods.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org/docs/jsonldcontext.jsonld",
-  "@id": "https://data.cultureelerfgoed.nl/term/id/cht/styles-and-periodes",
+  "@id": "https://data.cultureelerfgoed.nl/term/id/cht#styles-and-periodes",
   "@type": "Dataset",
   "name": [
     {

--- a/packages/network-of-terms-catalog/catalog/datasets/cht-styles-and-periods.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/cht-styles-and-periods.jsonld
@@ -63,7 +63,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/cht.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/cht.jsonld
@@ -84,7 +84,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/eurovoc.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/eurovoc.jsonld
@@ -60,7 +60,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/geonames.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/geonames.jsonld
@@ -54,7 +54,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/goudatijdmachine-straten.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/goudatijdmachine-straten.jsonld
@@ -57,7 +57,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/gtaa-classificatie.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/gtaa-classificatie.jsonld
@@ -54,7 +54,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/gtaa-genres.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/gtaa-genres.jsonld
@@ -54,7 +54,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/gtaa-geografische-namen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/gtaa-geografische-namen.jsonld
@@ -54,7 +54,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/gtaa-namen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/gtaa-namen.jsonld
@@ -57,7 +57,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/gtaa-onderwerpen-beng.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/gtaa-onderwerpen-beng.jsonld
@@ -57,7 +57,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/gtaa-onderwerpen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/gtaa-onderwerpen.jsonld
@@ -57,7 +57,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/gtaa-persoonsnamen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/gtaa-persoonsnamen.jsonld
@@ -54,7 +54,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/homosaurus.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/homosaurus.jsonld
@@ -54,7 +54,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/iconclass.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/iconclass.jsonld
@@ -60,7 +60,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/ied.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/ied.jsonld
@@ -69,7 +69,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/koloniaal-verleden.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/koloniaal-verleden.jsonld
@@ -66,7 +66,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/muziekschatten-klassieke-werken.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/muziekschatten-klassieke-werken.jsonld
@@ -54,7 +54,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/muziekschatten-onderwerpen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/muziekschatten-onderwerpen.jsonld
@@ -57,7 +57,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/muziekschatten-personen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/muziekschatten-personen.jsonld
@@ -54,7 +54,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/mw-genresstijlen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/mw-genresstijlen.jsonld
@@ -57,7 +57,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/mw-personengroepen.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/mw-personengroepen.jsonld
@@ -54,7 +54,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/nmvw.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/nmvw.jsonld
@@ -66,7 +66,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/nta.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/nta.jsonld
@@ -60,7 +60,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/rijksmonumenten.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/rijksmonumenten.jsonld
@@ -54,7 +54,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/rkdartists.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/rkdartists.jsonld
@@ -54,7 +54,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/stcn-drukkers.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/stcn-drukkers.jsonld
@@ -54,7 +54,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/uitvoeringsmedium.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/uitvoeringsmedium.jsonld
@@ -57,7 +57,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/wo2biografie.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/wo2biografie.jsonld
@@ -54,7 +54,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-catalog/catalog/datasets/wo2thesaurus.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/wo2thesaurus.jsonld
@@ -63,7 +63,7 @@
               "@id": "https://reconciliation-api.github.io/specs/latest/",
               "@type": "SoftwareApplication"
             },
-            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{distribution}"
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
           }
         }
       ]

--- a/packages/network-of-terms-graphql/README.md
+++ b/packages/network-of-terms-graphql/README.md
@@ -91,7 +91,7 @@ query Sources {
 # Query Cultuurhistorische Thesaurus (CHT)
 query {
   terms(
-    sources: ["https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht"],
+    sources: ["https://data.cultureelerfgoed.nl/term/id/cht"],
     query: "fiets"
   ) {
     source {
@@ -146,7 +146,7 @@ query {
 # Query RKDartists and NTA simultaneously
 query {
   terms(
-    sources: ["https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql", "http://data.bibliotheken.nl/thesp/sparql"],
+    sources: ["https://data.rkd.nl/rkdartists", "http://data.bibliotheken.nl/id/dataset/persons"],
     query: "Gogh"
   ) {
     source {

--- a/packages/network-of-terms-graphql/src/resolvers.ts
+++ b/packages/network-of-terms-graphql/src/resolvers.ts
@@ -39,9 +39,7 @@ async function queryTerms(object: any, args: any, context: any): Promise<any> {
     comunica: context.comunica,
   });
   const results = await service.queryAll({
-    sources: args.sources.map(
-      (distributionIri: string) => new IRI(distributionIri)
-    ),
+    sources: args.sources.map((datasetIri: string) => new IRI(datasetIri)),
     query: args.query,
     queryMode: QueryMode[args.queryMode as keyof typeof QueryMode],
     timeoutMs: args.timeoutMs,
@@ -141,7 +139,7 @@ function term(term: Term) {
 
 async function source(distribution: Distribution, dataset: Dataset) {
   return {
-    uri: distribution.iri,
+    uri: dataset.iri,
     name: dataset.name,
     alternateName: dataset.alternateName,
     description: dataset.description,

--- a/packages/network-of-terms-graphql/test/server.test.ts
+++ b/packages/network-of-terms-graphql/test/server.test.ts
@@ -143,45 +143,10 @@ describe('Server', () => {
       )
     );
     expect(body.data.terms).toHaveLength(1); // Source.
-    expect(body.data.terms[0].source.name).toEqual('RKDartists');
     expect(body.data.terms[0].source.uri).toEqual(
       'https://data.rkd.nl/rkdartists'
     );
-    expect(body.data.terms[0].source.inLanguage).toEqual(['nl']);
-    expect(body.data.terms[0].result.__typename).toEqual('Terms');
     expect(body.data.terms[0].result.terms).toHaveLength(5); // Terms found.
-    expect(body.data.terms[0].responseTimeMs).toBeGreaterThan(0);
-
-    const artwork = body.data.terms[0].result.terms.find(
-      (term: {uri: string}) =>
-        term.uri === 'https://example.com/resources/artwork'
-    );
-    expect(artwork.seeAlso).toEqual(['https://example.com/html/artwork']);
-    expect(artwork.description).toEqual([
-      'One of the most famous Dutch paintings',
-    ]);
-    expect(artwork.exactMatch).toEqual([
-      {
-        prefLabel: ['Exact match'],
-        uri: 'https://example.com/resources/match',
-      },
-    ]);
-
-    const prefLabels = body.data.terms[0].result.terms.map(
-      ({prefLabel}: {prefLabel: string[]}) => prefLabel[0] ?? ''
-    );
-    expect(prefLabels).toEqual([
-      'Rembrandt',
-      'Nachtwacht',
-      'All things art',
-      '',
-      '',
-    ]); // Results with score must come first.
-
-    const relatedPrefLabels = artwork.related.map(
-      ({prefLabel}: {prefLabel: string[]}) => prefLabel[0] ?? ''
-    );
-    expect(relatedPrefLabels).toEqual(['', 'All things art', 'Rembrandt']); // Sorted alphabetically.
   });
 
   it('responds to GraphQL lookup query', async () => {

--- a/packages/network-of-terms-graphql/test/server.test.ts
+++ b/packages/network-of-terms-graphql/test/server.test.ts
@@ -45,9 +45,7 @@ describe('Server', () => {
       `
     );
     expect(body.data.sources).toHaveLength(catalog.datasets.length);
-    expect(body.data.sources[0].uri).toEqual(
-      'https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql'
-    );
+    expect(body.data.sources[0].uri).toEqual('https://data.rkd.nl/rkdartists');
     expect(body.data.sources[0].mainEntityOfPage).toEqual([
       'https://example.com/rkdartists',
     ]);
@@ -93,6 +91,52 @@ describe('Server', () => {
 
   it('responds to successful GraphQL terms query', async () => {
     const body = await query(
+      termsQuery(['https://data.rkd.nl/rkdartists'], '.*')
+    );
+    expect(body.data.terms).toHaveLength(1); // Source.
+    expect(body.data.terms[0].source.name).toEqual('RKDartists');
+    expect(body.data.terms[0].source.uri).toEqual(
+      'https://data.rkd.nl/rkdartists'
+    );
+    expect(body.data.terms[0].source.inLanguage).toEqual(['nl']);
+    expect(body.data.terms[0].result.__typename).toEqual('Terms');
+    expect(body.data.terms[0].result.terms).toHaveLength(5); // Terms found.
+    expect(body.data.terms[0].responseTimeMs).toBeGreaterThan(0);
+
+    const artwork = body.data.terms[0].result.terms.find(
+      (term: {uri: string}) =>
+        term.uri === 'https://example.com/resources/artwork'
+    );
+    expect(artwork.seeAlso).toEqual(['https://example.com/html/artwork']);
+    expect(artwork.description).toEqual([
+      'One of the most famous Dutch paintings',
+    ]);
+    expect(artwork.exactMatch).toEqual([
+      {
+        prefLabel: ['Exact match'],
+        uri: 'https://example.com/resources/match',
+      },
+    ]);
+
+    const prefLabels = body.data.terms[0].result.terms.map(
+      ({prefLabel}: {prefLabel: string[]}) => prefLabel[0] ?? ''
+    );
+    expect(prefLabels).toEqual([
+      'Rembrandt',
+      'Nachtwacht',
+      'All things art',
+      '',
+      '',
+    ]); // Results with score must come first.
+
+    const relatedPrefLabels = artwork.related.map(
+      ({prefLabel}: {prefLabel: string[]}) => prefLabel[0] ?? ''
+    );
+    expect(relatedPrefLabels).toEqual(['', 'All things art', 'Rembrandt']); // Sorted alphabetically.
+  });
+
+  it('responds to successful GraphQL terms query with backwards compatible distribution URI', async () => {
+    const body = await query(
       termsQuery(
         ['https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql'],
         '.*'
@@ -100,6 +144,9 @@ describe('Server', () => {
     );
     expect(body.data.terms).toHaveLength(1); // Source.
     expect(body.data.terms[0].source.name).toEqual('RKDartists');
+    expect(body.data.terms[0].source.uri).toEqual(
+      'https://data.rkd.nl/rkdartists'
+    );
     expect(body.data.terms[0].source.inLanguage).toEqual(['nl']);
     expect(body.data.terms[0].result.__typename).toEqual('Terms');
     expect(body.data.terms[0].result.terms).toHaveLength(5); // Terms found.
@@ -151,6 +198,7 @@ describe('Server', () => {
     const term = body.data.lookup[0];
     expect(term.uri).toEqual('https://example.com/resources/art');
     expect(term.source.name).toEqual('RKDartists');
+    expect(term.source.uri).toEqual('https://data.rkd.nl/rkdartists');
     expect(term.result.__typename).toEqual('Term');
     expect(term.result.uri).toEqual('https://example.com/resources/art');
     expect(term.responseTimeMs).toBeGreaterThan(0);

--- a/packages/network-of-terms-query/src/catalog.ts
+++ b/packages/network-of-terms-query/src/catalog.ts
@@ -51,6 +51,12 @@ export class Dataset {
     readonly alternateName?: string
   ) {}
 
+  public getSparqlDistribution(): Distribution | undefined {
+    return this.distributions.find(
+      distribution => distribution instanceof SparqlDistribution
+    );
+  }
+
   public getDistributionByIri(iri: IRI): Distribution | undefined {
     return this.distributions.find(
       distribution => distribution.iri.toString() === iri.toString()

--- a/packages/network-of-terms-query/src/catalog.ts
+++ b/packages/network-of-terms-query/src/catalog.ts
@@ -3,9 +3,14 @@ import {URL} from 'url';
 export class Catalog {
   constructor(readonly datasets: ReadonlyArray<Dataset>) {}
 
+  /**
+   * Get dataset by IRI, accepting distribution IRIs too for BC.
+   */
   public getDatasetByIri(iri: IRI): Dataset | undefined {
-    return this.datasets.find(
-      dataset => dataset.iri.toString() === iri.toString()
+    return (
+      this.datasets.find(
+        dataset => dataset.iri.toString() === iri.toString()
+      ) ?? this.getDatasetByDistributionIri(iri)
     );
   }
 

--- a/packages/network-of-terms-query/src/distributions.ts
+++ b/packages/network-of-terms-query/src/distributions.ts
@@ -53,9 +53,7 @@ export class DistributionsService {
   async query(options: QueryOptions): Promise<TermsResponse> {
     const args = Joi.attempt(options, schemaQuery);
     this.logger.info(`Preparing to query source "${args.source}"...`);
-    const dataset =
-      this.catalog.getDatasetByIri(args.source) ??
-      this.catalog.getDatasetByDistributionIri(args.source);
+    const dataset = this.catalog.getDatasetByIri(args.source);
     if (dataset === undefined) {
       throw Error(`Source with URI "${args.source}" not found`);
     }

--- a/packages/network-of-terms-query/src/distributions.ts
+++ b/packages/network-of-terms-query/src/distributions.ts
@@ -53,11 +53,13 @@ export class DistributionsService {
   async query(options: QueryOptions): Promise<TermsResponse> {
     const args = Joi.attempt(options, schemaQuery);
     this.logger.info(`Preparing to query source "${args.source}"...`);
-    const dataset = await this.catalog.getDatasetByDistributionIri(args.source);
+    const dataset =
+      this.catalog.getDatasetByIri(args.source) ??
+      this.catalog.getDatasetByDistributionIri(args.source);
     if (dataset === undefined) {
       throw Error(`Source with URI "${args.source}" not found`);
     }
-    const distribution = dataset.getDistributionByIri(args.source)!;
+    const distribution = dataset.getSparqlDistribution()!;
     const queryService = new QueryTermsService({
       logger: this.logger,
       comunica: this.comunica,

--- a/packages/network-of-terms-reconciliation/src/manifest.ts
+++ b/packages/network-of-terms-reconciliation/src/manifest.ts
@@ -38,16 +38,14 @@ export class ServiceManifest {
 }
 
 export function findManifest(
-  distributionIri: IRI,
+  dataset: IRI,
   catalog: Catalog,
   root: string
 ): ServiceManifest | undefined {
-  const source = catalog.getDatasetByDistributionIri(distributionIri);
+  const source = catalog.getDatasetByIri(dataset);
   if (
     source &&
-    source
-      .getDistributionByIri(distributionIri)
-      ?.hasFeature(FeatureType.RECONCILIATION)
+    source.getSparqlDistribution()?.hasFeature(FeatureType.RECONCILIATION)
   ) {
     return new ServiceManifest(source.name, source.iri, root);
   }

--- a/packages/network-of-terms-reconciliation/src/query.ts
+++ b/packages/network-of-terms-reconciliation/src/query.ts
@@ -14,12 +14,12 @@ import {score} from './score.js';
  * We may want to make this smarter by batching queries and acting on Timeout responses.
  */
 export async function reconciliationQuery(
-  distributionIri: IRI,
+  datasetIri: IRI,
   query: ReconciliationQueryBatch,
   catalog: Catalog,
   queryTermsService: QueryTermsService
 ): Promise<ReconciliationResultBatch> {
-  const dataset = catalog.getDatasetByDistributionIri(distributionIri)!;
+  const dataset = catalog.getDatasetByIri(datasetIri)!;
   const distribution = dataset.distributions[0];
 
   return Object.entries(query).reduce(

--- a/packages/network-of-terms-reconciliation/src/server.ts
+++ b/packages/network-of-terms-reconciliation/src/server.ts
@@ -51,8 +51,8 @@ export async function server(
   });
 
   server.get<{Params: {'*': string}}>('/reconcile/*', (request, reply) => {
-    const distributionIri = new IRI(request.params['*']);
-    const manifest = findManifest(distributionIri, catalog, request.root);
+    const dataset = new IRI(request.params['*']);
+    const manifest = findManifest(dataset, catalog, request.root);
     if (manifest === undefined) {
       reply.code(404).send();
       return;
@@ -89,8 +89,8 @@ export async function server(
         );
         return;
       }
-      const distributionIri = new IRI(request.params['*']);
-      const manifest = findManifest(distributionIri, catalog, request.root);
+      const dataset = new IRI(request.params['*']);
+      const manifest = findManifest(dataset, catalog, request.root);
       if (manifest === undefined) {
         reply.code(404).send();
         return;
@@ -98,7 +98,7 @@ export async function server(
 
       reply.send(
         await reconciliationQuery(
-          distributionIri,
+          dataset,
           request.body as ReconciliationQueryBatch,
           catalog,
           queryTermsService

--- a/packages/network-of-terms-reconciliation/test/server.test.ts
+++ b/packages/network-of-terms-reconciliation/test/server.test.ts
@@ -31,6 +31,14 @@ describe('Server', () => {
   it('returns reconciliation service manifest', async () => {
     const response = await httpServer.inject({
       method: 'GET',
+      url: '/reconcile/https://data.rkd.nl/rkdartists',
+    });
+    expect(response.statusCode).toEqual(200);
+  });
+
+  it('returns reconciliation service manifest with backwards compatible distribution URI', async () => {
+    const response = await httpServer.inject({
+      method: 'GET',
       url: '/reconcile/https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql',
     });
     expect(response.statusCode).toEqual(200);
@@ -52,7 +60,7 @@ describe('Server', () => {
 
   it('responds to successful reconciliation API requests', async () => {
     const response = await reconciliationQuery(
-      'https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql'
+      'https://data.rkd.nl/rkdartists'
     );
     expect(response.statusCode).toEqual(200);
     const results = JSON.parse(response.body);
@@ -78,9 +86,26 @@ describe('Server', () => {
     expect(results.q3.result).toEqual([]); // No results.
   });
 
+  it('responds to successful reconciliation API request with backwards compatible distribution URI', async () => {
+    const response = await reconciliationQuery(
+      'https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql'
+    );
+    expect(response.statusCode).toEqual(200);
+    const results = JSON.parse(response.body);
+
+    expect(results.q1.result).toEqual([
+      {
+        id: 'https://example.com/resources/artwork',
+        name: 'Nachtwacht',
+        score: 100,
+        description: 'Nachtwacht alt',
+      },
+    ]);
+  });
+
   it('limits reconciliation API results', async () => {
     const response = await reconciliationQuery(
-      'https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql',
+      'https://data.rkd.nl/rkdartists',
       {
         q1: {
           query: 'art',
@@ -99,7 +124,7 @@ describe('Server', () => {
 
   it('validates reconciliation requests', async () => {
     const response = await reconciliationQuery(
-      'https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql',
+      'https://data.rkd.nl/rkdartists',
       {
         q1: {
           query: 'art',
@@ -137,7 +162,7 @@ describe('Server', () => {
 
     // This is what OpenRefine currently expects.
     const response2 = await dataExtensionQuery(
-      '/reconcile/https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql/extend'
+      '/reconcile/https://data.rkd.nl/rkdartists/extend'
     );
     expect(response2.statusCode).toEqual(200);
     const results2 = JSON.parse(response.body);


### PR DESCRIPTION
Fix #1423

Terminology sources are no longer identifier by their distribution URI.
Keep BC by still allowing the distribution URI to be used when searching.
The sources query now returns the new source instead of distribution URIs.
