### PR TITLE
fix: goudse straten - pid property change

### DIFF
--- a/packages/network-of-terms-catalog/catalog/queries/search/goudatijdmachine-straten.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/goudatijdmachine-straten.rq
@@ -22,9 +22,8 @@ CONSTRUCT {
         luc:query ?query ;
         luc:entities ?uri .
 
-    ?uri sdo:identifier ?pid
-    FILTER(STRSTARTS(?pid, "https://n2t.net"))
-    BIND(IRI(?pid) AS ?piduri)
+    ?uri owl:sameAs ?piduri
+    FILTER(STRSTARTS(STR(?piduri), "https://n2t.net"))
 
     ?uri sdo:name ?prefLabel ;
         luc:score ?score .


### PR DESCRIPTION
PIDs in the GTM KG used to be in the sdo:identifier property, but have moved to the owl:sameAs property, this made the ETL pipeline much easier.