### PR TITLE
test: Fix code coverage on Node 22

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,8 +12,8 @@ export default {
     global: {
       lines: 91.39,
       statements: 91.39,
-      branches: 95.46,
-      functions: 92.62,
+      branches: 92.62,
+      functions: 90.9,
     },
   },
   transform: {


### PR DESCRIPTION
Node 22, recently promoted to LTS, reports incorrect code coverage:
https://github.com/nodejs/node/issues/51251.

The simplest solution for now is just to update our threshold to
Node 22’s reported coverage level.