### PR TITLE
fix: Filter by skos:Concept in Poolparty sources

### DIFF
--- a/packages/network-of-terms-catalog/catalog/queries/search/poolparty.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/poolparty.rq
@@ -16,7 +16,8 @@ CONSTRUCT {
     ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
 }
 WHERE {
-    ?uri ?predicate ?label .
+    ?uri a skos:Concept ;
+        ?predicate ?label .
     VALUES ?predicate { skos:prefLabel skos:altLabel }
     FILTER(LANG(?label) = "nl")
     FILTER(CONTAINS(LCASE(?label), LCASE(?query)))


### PR DESCRIPTION
The Poolparty search query now returns concepts of type
`<http://schema.semantic-web.at/ppt/suggested#Concept>`,
brought to light by the new PiCoT thesaurus. We probably want
to return only published Concepts, so filter by that.