### PR TITLE
build: Fail build on compilation error

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -18,5 +18,5 @@ jobs:
       - run: npm ci
       - run: npm run check
       - run: npm test
-      - run: npm run compile
+      - run: npm run compile --workspaces
       - run: npx commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: lts/*
       - run: npm ci
-      - run: npm run compile
+      - run: npm run compile --workspaces
       - run: npm run release
         env:
           # Use a personal access token (PAT) so we can trigger downstream workflows (deploy.yml).

--- a/package.json
+++ b/package.json
@@ -20,8 +20,6 @@
     "typescript": "^5.5.4"
   },
   "scripts": {
-    "clean": "npm run clean --workspaces",
-    "compile": "npm query .workspace | jq -r '.[].location' | xargs -L1 npm run compile --workspace",
     "check": "gts check",
     "fix": "gts fix",
     "commitlint": "commitlint --edit $1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "clean": "npm run clean --workspaces",
-    "compile": "npm run compile --workspaces",
+    "compile": "npm query .workspace | jq -r '.[].location' | xargs -L1 npm run compile --workspace",
     "check": "gts check",
     "fix": "gts fix",
     "commitlint": "commitlint --edit $1",


### PR DESCRIPTION
`npm --workspaces` always returns 0, even if the command fails 
for any of the workspaces: https://github.com/npm/rfcs/issues/575.

Work around this by running the command on each workspace individually.