### PR TITLE
Change SPARQL endpoints KB sources

### DIFF
--- a/packages/network-of-terms-catalog/catalog/datasets/brinkman.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/brinkman.jsonld
@@ -41,7 +41,7 @@
     {
       "@id": "http://data.bibliotheken.nl/thes/brinkman/sparql",
       "@type": "DataDownload",
-      "contentUrl": "http://194.30.182.3/sparql",
+      "contentUrl": "https://data.bibliotheken.nl/sparql",
       "encodingFormat": "application/sparql-query",
       "potentialAction": [
         {

--- a/packages/network-of-terms-catalog/catalog/datasets/nta.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/nta.jsonld
@@ -41,7 +41,7 @@
     {
       "@id": "http://data.bibliotheken.nl/thesp/sparql",
       "@type": "DataDownload",
-      "contentUrl": "http://194.30.182.3/sparql",
+      "contentUrl": "https://data.bibliotheken.nl/sparql",
       "encodingFormat": "application/sparql-query",
       "potentialAction": [
         {

--- a/packages/network-of-terms-catalog/catalog/datasets/stcn-drukkers.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/stcn-drukkers.jsonld
@@ -35,7 +35,7 @@
     {
       "@id": "http://data.bibliotheken.nl/thes/drukkers/sparql",
       "@type": "DataDownload",
-      "contentUrl": "http://194.30.182.3/sparql",
+      "contentUrl": "https://data.bibliotheken.nl/sparql",
       "encodingFormat": "application/sparql-query",
       "potentialAction": [
         {


### PR DESCRIPTION
SPARQL endpoint now serviced by TriplyDB (with Virtuoso service to retain <bif:contains> functionality). 
contentUrl was http but always redirected to https, so changed that too.