### PR TITLE
feat: Support multilingual search queries

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,10 +10,10 @@ export default {
   ],
   coverageThreshold: {
     global: {
-      lines: 91.87,
-      statements: 91.87,
-      branches: 1.82,
-      functions: 91.26,
+      lines: 92.29,
+      statements: 92.29,
+      branches: 92.93,
+      functions: 91.74,
     },
   },
   transform: {

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/geonames.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/geonames.rq
@@ -5,7 +5,7 @@ CONSTRUCT {
     ?uri a skos:Concept ;
         skos:prefLabel ?prefLabel_ext ;
         skos:altLabel ?altLabel ;
-        skos:scopeNote ?scopeNote ;
+        skos:scopeNote ?scopeNote_en ;
         skos:broader ?broader .
     ?broader skos:prefLabel ?broader_prefLabel .
 }
@@ -17,7 +17,7 @@ WHERE {
         gn:countryCode ?countryCode ;
         gn:name ?prefLabel .
 
-    BIND(CONCAT(?prefLabel," (",UCASE(?countryCode),")") as ?prefLabel_ext) 
+    BIND(CONCAT(?prefLabel," (",UCASE(?countryCode),")") as ?prefLabel_ext)
 
     OPTIONAL {
         ?uri gn:alternateName ?altLabel .
@@ -34,6 +34,8 @@ WHERE {
 
     OPTIONAL {
         ?uri gn:featureCode/gn:name ?scopeNote .
+        # scopeNote is always in English.
+        BIND(STRLANG(?scopeNote, "en") as ?scopeNote_en)
     }
 }
 LIMIT 1000

--- a/packages/network-of-terms-catalog/catalog/queries/search/geonames.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/geonames.rq
@@ -7,7 +7,7 @@ CONSTRUCT {
     ?uri a skos:Concept ;
         skos:prefLabel ?prefLabel_ext ;
         skos:altLabel ?altLabel ;
-        skos:scopeNote ?scopeNote ;
+        skos:scopeNote ?scopeNote_en ;
         skos:broader ?broader ;
         vrank:simpleRank ?score .
     ?broader skos:prefLabel ?broader_prefLabel .
@@ -46,5 +46,7 @@ WHERE {
 
     OPTIONAL {
         ?uri gn:featureCode/gn:name ?scopeNote .
+        # scopeNote is always in English.
+        BIND(STRLANG(?scopeNote, "en") as ?scopeNote_en)
     }
 }

--- a/packages/network-of-terms-catalog/test/catalog.test.ts
+++ b/packages/network-of-terms-catalog/test/catalog.test.ts
@@ -112,6 +112,10 @@ describe('Catalog', () => {
     ).toEqual('https://username:password@gtaa.apis.beeldengeluid.nl/sparql');
   });
 
+  it('returns all languages', async () => {
+    expect(catalog.getLanguages()).toEqual(['en', 'nl']);
+  });
+
   it('loads catalog from a path', async () => {
     const catalog = await getCatalog(
       resolve(dirname(fileURLToPath(import.meta.url)), '../', 'catalog/')

--- a/packages/network-of-terms-graphql/src/schema.ts
+++ b/packages/network-of-terms-graphql/src/schema.ts
@@ -1,4 +1,4 @@
-export const schema = `
+export const schema = (languages: string[]) => `
   """
   A term source is a collection of terms.
   """
@@ -10,7 +10,7 @@ export const schema = `
     creators: [Creator]!
     features: [Feature]!
     genres: [Genre]!
-    inLanguage: [String]!
+    inLanguage: [Language]!
     mainEntityOfPage: [String]!
   }
 
@@ -45,7 +45,7 @@ export const schema = `
   }
 
   """
-  A description of a concept or entity, expressed in the SKOS vocabulary, used to describe objects.
+  A description of a concept or entity, expressed in the SKOS vocabulary.
   """
   type Term {
     uri: ID!
@@ -66,6 +66,10 @@ export const schema = `
     uri: ID!
     prefLabel: [String]!
   }
+  
+  enum Language {
+    ${languages.join(' ')}
+  }
 
   type Query {
     "Query one or more sources for terms."
@@ -77,7 +81,10 @@ export const schema = `
       query: String!,
 
       "The mode in which the literal search query (\`query\`) is interpreted before it is sent to the term sources."      
-      queryMode: QueryMode = OPTIMIZED
+      queryMode: QueryMode = OPTIMIZED,
+      
+      "List of languages in which to return terms. If one or more languages are specified, terms are returned as \`TranslatedTerm\`s."
+      languages: [Language],
       
       "Maximum number of terms to return."
       limit: Int = 100,
@@ -120,10 +127,38 @@ export const schema = `
     responseTimeMs: Int!
   }
 
-  union TermsResult = Terms | TimeoutError | ServerError
+  union TermsResult = Terms | TranslatedTerms | TimeoutError | ServerError
 
   type Terms {
     terms: [Term]
+  }
+  
+  type TranslatedTerms {
+    terms: [TranslatedTerm]
+  }
+  
+  type TranslatedTerm {
+    uri: ID!
+    prefLabel: [LanguageString]!
+    altLabel: [LanguageString]!
+    hiddenLabel: [LanguageString]!
+    definition: [LanguageString]!
+    scopeNote: [LanguageString]!
+    seeAlso: [String]!
+    broader: [TranslatedRelatedTerm]
+    narrower: [TranslatedRelatedTerm]
+    related: [TranslatedRelatedTerm]
+    exactMatch: [TranslatedRelatedTerm]
+  }
+  
+  type TranslatedRelatedTerm {
+    uri: ID!
+    prefLabel: [LanguageString]!
+  }
+  
+  type LanguageString {
+    language: Language!
+    value: String!
   }
 
   type LookupQueryResult {

--- a/packages/network-of-terms-graphql/src/server.ts
+++ b/packages/network-of-terms-graphql/src/server.ts
@@ -28,7 +28,7 @@ export async function server(
   const server = fastify({logger, trustProxy: config.TRUST_PROXY as boolean});
   server.register(fastifyAccepts);
   server.register(mercurius, {
-    schema,
+    schema: schema(catalog.getLanguages()),
     resolvers,
     graphiql: true,
     context: async (req: FastifyRequest) => {

--- a/packages/network-of-terms-query/src/catalog.ts
+++ b/packages/network-of-terms-query/src/catalog.ts
@@ -54,6 +54,19 @@ export class Catalog {
   }
 
   /**
+   * Get all languages provided by datasets in this catalog.
+   */
+  public getLanguages(): string[] {
+    return [
+      ...new Set(
+        this.datasets.reduce<string[]>((acc, dataset) => {
+          return [...acc, ...dataset.inLanguage];
+        }, [])
+      ),
+    ];
+  }
+
+  /**
    * Index the prefixes of all datasets by their string length in descending order for matching
    * term IRIs against during lookup. When looking up terms, we want to match the longest possible prefix
    * in case prefixes overlap.

--- a/packages/network-of-terms-query/src/server-test.ts
+++ b/packages/network-of-terms-query/src/server-test.ts
@@ -21,7 +21,7 @@ export const testCatalog = (port: number) =>
   new Catalog([
     new Dataset(
       new IRI('https://data.rkd.nl/rkdartists'),
-      {nl: 'RKDartists'},
+      {nl: 'RKDartists', en: 'RKDartists'},
       {
         nl: 'Biografische gegevens van Nederlandse en buitenlandse kunstenaars van de middeleeuwen tot heden',
       },
@@ -51,17 +51,23 @@ export const testCatalog = (port: number) =>
           CONSTRUCT { 
             ?s ?p ?o 
           }
-          WHERE { 
-            ?s ?p ?o ;
-              ?labelPredicate ?label .
-            VALUES ?labelPredicate { skos:prefLabel skos:altLabel skos:hiddenLabel }
-            FILTER (regex(?label, ?query, "i"))
+          WHERE {
+            {
+              SELECT DISTINCT ?s WHERE {
+                ?s ?labelPredicate ?label .
+                VALUES ?labelPredicate { skos:prefLabel skos:altLabel skos:hiddenLabel }
+                FILTER (regex(?label, ?query, "i"))            
+              }
+              #LIMIT#
+            }
+              
+            ?s ?p ?o .
+           
             OPTIONAL { 
               ?s skos:exactMatch ?match .
               ?match skos:prefLabel ?match_label .
-            }
-          }
-          #LIMIT#`,
+            }  
+          }`,
           `
           PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
           CONSTRUCT {

--- a/packages/network-of-terms-query/test/fixtures/terms.ttl
+++ b/packages/network-of-terms-query/test/fixtures/terms.ttl
@@ -4,8 +4,8 @@
 
 <https://example.com/resources/artwork>
     a skos:Concept ;
-    skos:prefLabel "Nachtwacht"@nl ;
-    skos:altLabel "Nachtwacht alt"@en ;
+    skos:prefLabel "Nachtwacht"@nl, "The Night Watch"@en ;
+    skos:altLabel "Nachtwacht alt"@nl, "Night Watch alt"@en ;
     skos:scopeNote "One of the most famous Dutch paintings"@en ;
     skos:hiddenLabel "art" ;
     skos:broader <https://example.com/resources/2> ;
@@ -20,8 +20,10 @@
 <https://example.com/resources/painting>
     a <http://www.w3.org/2008/05/skos#Concept> ;
     skos:altLabel
-        "painted things that can be beautiful"@en,
-        "another altLabel"@en ;
+        "painted things that can be beautiful"@en ,
+        "another altLabel"@en ,
+        "mooie geschilderde dingen"@nl ,
+        "en nog meer"@nl ;
     skos:related <https://example.com/resources/art> ;
     skos:broader <https://example.com/resources/art> .
 
@@ -32,7 +34,7 @@
 
 <https://example.com/resources/art>
     a skos:Concept ;
-    skos:prefLabel "All things art"@en ;
+    skos:prefLabel "All things art"@en, "Kunstige dingen"@nl ;
     skos:altLabel "Art"@en ;
     skos:narrower <https://example.com/resources/artwork> .
 

--- a/packages/network-of-terms-reconciliation/src/data-extension.ts
+++ b/packages/network-of-terms-reconciliation/src/data-extension.ts
@@ -27,7 +27,11 @@ export const dataExtensionProperties: {
   },
 ];
 
-export async function extendQuery(terms: IRI[], lookupService: LookupService) {
+export async function extendQuery(
+  terms: IRI[],
+  lookupService: LookupService,
+  language: string
+) {
   const lookupResults = (await lookupService.lookup(terms, 10000)).filter(
     lookupResult => lookupResult.result instanceof Term
   );
@@ -38,9 +42,11 @@ export async function extendQuery(terms: IRI[], lookupService: LookupService) {
       id: lookupResult.uri.toString(),
       properties: dataExtensionProperties.map(property => ({
         id: property.id,
-        values: (lookupResult.result as Term)[property.id].map(literal => ({
-          str: literal.value,
-        })),
+        values: (lookupResult.result as Term)[property.id]
+          .filter(literal => literal.language === language)
+          .map(literal => ({
+            str: literal.value,
+          })),
       })),
     })),
   };

--- a/packages/network-of-terms-reconciliation/src/preview.ts
+++ b/packages/network-of-terms-reconciliation/src/preview.ts
@@ -11,7 +11,8 @@ import {locale} from './server.js';
 export function preview(
   lookupResult: LookupQueryResult,
   source: Dataset,
-  locale: locale
+  locale: locale,
+  language: string
 ) {
   const term = lookupResult.result;
   if (term instanceof Term) {
@@ -25,12 +26,12 @@ export function preview(
       </style>
     </head>
     <body>
-      <h1>${literal(term.prefLabels)}</h1>
-      <p>${literal(term.scopeNotes)}</p>
+      <h1>${literal(term.prefLabels, language)}</h1>
+      <p>${literal(term.scopeNotes, language)}</p>
       <dl>
         ${
           term.altLabels.length > 0
-            ? `<dt>${locale.altLabels}</dt><dd>${literal(term.altLabels)}</dd>`
+            ? `<dt>${locale.altLabels}</dt><dd>${literal(term.altLabels, language)}</dd>`
             : ''
         }
         ${relatedTerms(locale.broader, term.broaderTerms)}
@@ -49,8 +50,11 @@ export function preview(
   }
 }
 
-const literal = (values: Literal[]) =>
-  values.map(literal => literal.value).join(' • ');
+const literal = (values: Literal[], language: string) =>
+  values
+    .filter(value => value.language === language)
+    .map(literal => literal.value)
+    .join(' • ');
 
 function relatedTerms(label: string, terms: RelatedTerm[]) {
   const termsWithPrefLabel = terms.filter(term => term.prefLabels.length > 0);

--- a/packages/network-of-terms-reconciliation/src/query.ts
+++ b/packages/network-of-terms-reconciliation/src/query.ts
@@ -17,7 +17,8 @@ export async function reconciliationQuery(
   datasetIri: IRI,
   query: ReconciliationQueryBatch,
   catalog: Catalog,
-  queryTermsService: QueryTermsService
+  queryTermsService: QueryTermsService,
+  language: string
 ): Promise<ReconciliationResultBatch> {
   const dataset = catalog.getDatasetByIri(datasetIri)!;
   const distribution = dataset.distributions[0];
@@ -42,9 +43,15 @@ export async function reconciliationQuery(
         result: terms
           .map(term => ({
             id: term.id.value.toString(),
-            name: term.prefLabels.map(label => label.value).join(' • '), // Join similarly to network-of-terms-demo.
+            name: term.prefLabels
+              .filter(prefLabel => prefLabel.language === language)
+              .map(label => label.value)
+              .join(' • '), // Join similarly to network-of-terms-demo.
             score: score(queryString, term),
-            description: term.altLabels.map(label => label.value).join(' • '),
+            description: term.altLabels
+              .filter(prefLabel => prefLabel.language === language)
+              .map(label => label.value)
+              .join(' • '),
           }))
           .sort((a, b) => b.score - a.score)
           .slice(0, limit),

--- a/packages/network-of-terms-reconciliation/src/server.ts
+++ b/packages/network-of-terms-reconciliation/src/server.ts
@@ -71,20 +71,23 @@ export async function server(
       },
     },
     async (request, reply) => {
+      const language = request.languages(['nl', 'en']) || 'nl';
       // BC for Reconciliation API spec 0.2.
       if (request.body.ids) {
         await extendQuery(
           (request.body as DataExtensionQuery).ids.map(
             termIri => new IRI(termIri)
           ),
-          lookupService
+          lookupService,
+          language
         );
         reply.send(
           await extendQuery(
             (request.body as DataExtensionQuery).ids.map(
               termIri => new IRI(termIri)
             ),
-            lookupService
+            lookupService,
+            language
           )
         );
         return;
@@ -101,7 +104,8 @@ export async function server(
           dataset,
           request.body as ReconciliationQueryBatch,
           catalog,
-          queryTermsService
+          queryTermsService,
+          language
         )
       );
     }
@@ -125,7 +129,8 @@ export async function server(
       reply.send(
         await extendQuery(
           request.body.ids.map(termIri => new IRI(termIri)),
-          lookupService
+          lookupService,
+          request.languages(['nl', 'en']) || 'nl'
         )
       );
     }
@@ -141,7 +146,7 @@ export async function server(
 
     reply
       .type('text/html')
-      .send(preview(lookupResult, source, locales[language]));
+      .send(preview(lookupResult, source, locales[language], language));
   });
 
   return server;


### PR DESCRIPTION
* Filter reconciliation queries by single language.
* Add `languages` GraphQL query argument. If passed, results are
  returned as language/value-tagged strings instead of plain strings.
* If that `languages` argument is passed, the first language 
  becomes the catalog language. If not, fall back to the `Accept-Language`
  header.
* Define languages as enum in GraphQL schema and base its values
  on the languages provided in the catalog’s datasets.

Ref #1410