### PR TITLE
feat: Add Fuseki and QLever endpoints for full GeoNames

### DIFF
--- a/packages/network-of-terms-catalog/catalog/datasets/geonames-full-fuseki.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/geonames-full-fuseki.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": "https://schema.org",
+  "@id": "https://www.geonames.org/full-fuseki",
+  "@type": "Dataset",
+  "name": [
+    {
+      "@language": "en",
+      "@value": "GeoNames (Fuseki)"
+    },
+    {
+      "@language": "nl",
+      "@value": "GeoNames (Fuseki)"
+    }
+  ],
+  "genre": [
+    {
+      "@id": "https://data.cultureelerfgoed.nl/termennetwerk/onderwerpen/Locaties"
+    }
+  ],
+  "creator": [
+    {
+      "@id": "https://www.geonames.org/team.html"
+    }
+  ],
+  "url": [
+    "https://sws.geonames.org/"
+  ],
+  "mainEntityOfPage": [
+    "https://www.geonames.org/about.html"
+  ],
+  "description": [
+    {
+      "@language": "en",
+      "@value": "Selection of geographical names such as places, administrative divisions (municipalities, provinces) and water bodies (rivers, streams, lakes etc.)"
+    },
+    {
+      "@language": "nl",
+      "@value": "Selectie van geografische namen zoals plaatsen, administratieve eenheden (gemeentes, provincies) en waterlichamen (rivieren, beken, meren etc.)"
+    }
+  ],
+  "inLanguage": "en",
+  "distribution": [
+    {
+      "@id": "https://demo.netwerkdigitaalerfgoed.nl/geonames2",
+      "@type": "DataDownload",
+      "contentUrl": "https://demo.netwerkdigitaalerfgoed.nl/geonames2/sparql",
+      "encodingFormat": "application/sparql-query",
+      "potentialAction": [
+        {
+          "@type": "SearchAction",
+          "query": "file://catalog/queries/search/geonames.rq"
+        },
+        {
+          "@type": "FindAction",
+          "query": "file://catalog/queries/lookup/geonames.rq"
+        },
+        {
+          "@type": "Action",
+          "target": {
+            "@type": "EntryPoint",
+            "actionApplication": {
+              "@id": "https://reconciliation-api.github.io/specs/latest/",
+              "@type": "SoftwareApplication"
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/network-of-terms-catalog/catalog/datasets/geonames-full-qlever.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/geonames-full-qlever.jsonld
@@ -1,0 +1,71 @@
+{
+  "@context": "https://schema.org",
+  "@id": "https://www.geonames.org/full-qlever",
+  "@type": "Dataset",
+  "name": [
+    {
+      "@language": "en",
+      "@value": "GeoNames (QLever)"
+    },
+    {
+      "@language": "nl",
+      "@value": "GeoNames (QLever)"
+    }
+  ],
+  "genre": [
+    {
+      "@id": "https://data.cultureelerfgoed.nl/termennetwerk/onderwerpen/Locaties"
+    }
+  ],
+  "creator": [
+    {
+      "@id": "https://www.geonames.org/team.html"
+    }
+  ],
+  "url": [
+    "https://sws.geonames.org/"
+  ],
+  "mainEntityOfPage": [
+    "https://www.geonames.org/about.html"
+  ],
+  "description": [
+    {
+      "@language": "en",
+      "@value": "Selection of geographical names such as places, administrative divisions (municipalities, provinces) and water bodies (rivers, streams, lakes etc.)"
+    },
+    {
+      "@language": "nl",
+      "@value": "Selectie van geografische namen zoals plaatsen, administratieve eenheden (gemeentes, provincies) en waterlichamen (rivieren, beken, meren etc.)"
+    }
+  ],
+  "inLanguage": "en",
+  "distribution": [
+    {
+      "@id": "https://demo.netwerkdigitaalerfgoed.nl/geonames-qlever",
+      "@type": "DataDownload",
+      "contentUrl": "https://demo.netwerkdigitaalerfgoed.nl/geonames-qlever/sparql",
+      "encodingFormat": "application/sparql-query",
+      "potentialAction": [
+        {
+          "@type": "SearchAction",
+          "query": "file://catalog/queries/search/geonames-qlever.rq"
+        },
+        {
+          "@type": "FindAction",
+          "query": "file://catalog/queries/lookup/geonames.rq"
+        },
+        {
+          "@type": "Action",
+          "target": {
+            "@type": "EntryPoint",
+            "actionApplication": {
+              "@id": "https://reconciliation-api.github.io/specs/latest/",
+              "@type": "SoftwareApplication"
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/network-of-terms-catalog/catalog/queries/search/geonames-qlever.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/geonames-qlever.rq
@@ -1,0 +1,55 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX gn: <https://www.geonames.org/ontology#>
+PREFIX ql: <http://qlever.cs.uni-freiburg.de/builtin-functions/>
+PREFIX text: <http://jena.apache.org/text#>
+PREFIX vrank: <http://purl.org/voc/vrank#>
+
+CONSTRUCT {
+    ?uri a skos:Concept ;
+        skos:prefLabel ?prefLabel_ext ;
+        skos:altLabel ?altLabel ;
+        skos:scopeNote ?scopeNote_en ;
+        skos:broader ?broader ;
+        vrank:simpleRank ?score .
+    ?broader skos:prefLabel ?broader_prefLabel .
+}
+WHERE {
+    {
+        SELECT DISTINCT ?uri (COUNT(?text) as ?score) WHERE {
+            ?uri a gn:Feature ;
+                gn:featureClass ?featureClass .
+            # Limit results to places (P), localities (L), administrative levels (A) and water surfaces (H).
+            VALUES ?featureClass { gn:P gn:L gn:A gn:H }
+
+            ?text ql:contains-entity ?uri ;
+                ql:contains-word ?query .
+        }
+        GROUP BY ?uri
+        ORDER BY DESC(?score)
+        #LIMIT#
+    }
+
+    ?uri gn:name ?prefLabel ;
+        gn:countryCode ?countryCode .
+
+    BIND(CONCAT(?prefLabel," (",UCASE(?countryCode),")") as ?prefLabel_ext)
+
+    OPTIONAL {
+        ?uri gn:alternateName ?altLabel .
+        FILTER(?altLabel != "")
+    }
+
+    OPTIONAL {
+        ?uri ?parents ?broader .
+        ?broader gn:name ?broader_prefLabel
+        VALUES ?parents { gn:parentADM1 gn:parentADM2 }
+        # filter out the circular links in the converted data
+        FILTER(?uri != ?broader)
+    }
+
+    OPTIONAL {
+        ?uri gn:featureCode/gn:name ?scopeNote .
+        # scopeNote is always in English.
+        BIND(STRLANG(?scopeNote, "en") as ?scopeNote_en)
+    }
+}


### PR DESCRIPTION
Ref #1562

Check out this branch locally, then try it out with this GraphQL query:

```graphql
query {
  terms(
    sources: [
      "https://www.geonames.org",
      "https://www.geonames.org/full-fuseki",
      "https://www.geonames.org/full-qlever",
    ],
    query: "utrecht",  
    languages: [en, nl]
  ) {
    source {
      uri
      name
    }
    result {
      __typename
#       # ... on TranslatedTerms {
#       #   terms {
#       #     uri
#       #     prefLabel { language value }
#       #     altLabel { language value }
#       #     hiddenLabel { language value}
#       #     definition { language value }
#       #     scopeNote { language value }
#       #     seeAlso
#       #   }
#       # }
#       ... on TranslatedTerms {
#          terms {
#           uri
        
#           prefLabel { language value }
#           scopeNote { language value }
#           definition {language value}
#           exactMatch {
#             uri
            
#           }
#           narrower {
#             uri
#             prefLabel {language value}
#           }
#           broader { uri prefLabel {language value} }
#           related { uri prefLabel{language value}}
          
          
#         }
#       }
#       ... on Error {
#         message
#       }
    }
    responseTimeMs
  }
}
```