### PR TITLE
feat: filter guideterms from AAT SPARQL-query

### DIFF
--- a/packages/network-of-terms-catalog/catalog/datasets/westerbork.jsonld
+++ b/packages/network-of-terms-catalog/catalog/datasets/westerbork.jsonld
@@ -47,11 +47,13 @@
   "description": [
     {
       "@language": "en",
-      "@value": "Subjects for describing the history of WW2 and Camp Westerbork"
+      "@value": "Terms for describing and contextualising collections relating to the history of Camp Westerbork (1939-1971) and dealing with the historical site (1971-present)."
     },
     {
       "@language": "nl",
-      "@value": "Onderwerpen voor het beschrijven van de geschiedenis van de Tweede Wereldoorlog en Kamp Westerbork"
+      "@value": "Termen voor het beschrijven en contextualiseren van collecties die betrekking hebben op de geschiedenis van kamp Westerbork (1939-1971) en omgang met de historische plek (1971-heden).
+
+ "
     }
   ],
   "inLanguage": ["nl"],

--- a/packages/network-of-terms-catalog/catalog/queries/lookup/aat.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/lookup/aat.rq
@@ -23,6 +23,9 @@ WHERE {
     # Bicycles: <http://vocab.getty.edu/aat/300212636>
     # Wars: <http://vocab.getty.edu/aat/300055314>
     VALUES ?uri { ?uris }
+	
+#voor het filteren van de gidstermen zodat deze niet toegepast worden in de CMS.
+    FILTER NOT EXISTS { ?uri a gvp:GuideTerm }
 
     VALUES ?language {
         aat:300388256 # Dutch

--- a/packages/network-of-terms-catalog/catalog/queries/search/aat-materials.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/aat-materials.rq
@@ -35,6 +35,8 @@ WHERE {
                 gvp:broaderPreferred+ <http://vocab.getty.edu/aat/300010357> . # limit results to the "materials hierarchy name" (300010357)
             ?type rdfs:subClassOf gvp:Subject .
             FILTER (?type != gvp:Subject) .
+#voor het filteren van de gidstermen zodat deze niet toegepast worden in de CMS.
+            FILTER NOT EXISTS { ?uri a gvp:GuideTerm }
             ?uri skosxl:prefLabel [
                 dcterms:language ?language ; # Faster than FILTER(langMatches(...): https://vocab.getty.edu/queries#Find_Terms_by_Language_Tag
                 skosxl:literalForm ?prefLabel

--- a/packages/network-of-terms-catalog/catalog/queries/search/aat-processes-and-techniques.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/aat-processes-and-techniques.rq
@@ -35,6 +35,8 @@ WHERE {
                 gvp:broaderPreferred+ <http://vocab.getty.edu/aat/300053001> . # limit results to the "processes and techniques hierarchy name (300053001)"
             ?type rdfs:subClassOf gvp:Subject .
             FILTER (?type != gvp:Subject) .
+#voor het filteren van de gidstermen zodat deze niet toegepast worden in de CMS.
+            FILTER NOT EXISTS { ?uri a gvp:GuideTerm }
             ?uri skosxl:prefLabel [
                 dcterms:language ?language ; # Faster than FILTER(langMatches(...): https://vocab.getty.edu/queries#Find_Terms_by_Language_Tag
                 skosxl:literalForm ?prefLabel

--- a/packages/network-of-terms-catalog/catalog/queries/search/aat-styles-and-periods.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/aat-styles-and-periods.rq
@@ -35,6 +35,8 @@ WHERE {
             gvp:broaderPreferred+ <http://vocab.getty.edu/aat/300015646> . # limit results to the "styles and periodes hierarchy name (300015646)"
             ?type rdfs:subClassOf gvp:Subject .
             FILTER (?type != gvp:Subject) .
+#voor het filteren van de gidstermen zodat deze niet toegepast worden in de CMS.
+            FILTER NOT EXISTS { ?uri a gvp:GuideTerm }
             ?uri skosxl:prefLabel [
                 dcterms:language ?language ; # Faster than FILTER(langMatches(...): https://vocab.getty.edu/queries#Find_Terms_by_Language_Tag
                 skosxl:literalForm ?prefLabel

--- a/packages/network-of-terms-catalog/catalog/queries/search/aat.rq
+++ b/packages/network-of-terms-catalog/catalog/queries/search/aat.rq
@@ -34,6 +34,8 @@ WHERE {
                 void:inDataset <http://vocab.getty.edu/dataset/aat> .
             ?type rdfs:subClassOf gvp:Subject .
             FILTER (?type != gvp:Subject) .
+#voor het filteren van de gidstermen zodat deze niet toegepast worden in de CMS.
+            FILTER NOT EXISTS { ?uri a gvp:GuideTerm }
             ?uri skosxl:prefLabel [
                 dcterms:language ?language ; # Faster than FILTER(langMatches(...): https://vocab.getty.edu/queries#Find_Terms_by_Language_Tag
                 skosxl:literalForm ?prefLabel


### PR DESCRIPTION
feat: this PR adds a FILTER NOT EXISTS for gvp:GuideTerm to exclude guide terms 
from SPARQL queries used in the CMS export.

Task: Filter guide terms from SPARQL AAT export
Closes #1567