### PR TITLE
fix: Preserve dataset URIs

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,9 +10,9 @@ export default {
   ],
   coverageThreshold: {
     global: {
-      statements: 92.38,
+      statements: 92.33,
       branches: 93.62,
-      lines: 92.38,
+      lines: 92.33,
       functions: 91.66,
     },
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,9 +10,9 @@ export default {
   ],
   coverageThreshold: {
     global: {
-      statements: 92.37,
-      branches: 93.69,
-      lines: 92.37,
+      statements: 92.38,
+      branches: 93.62,
+      lines: 92.38,
       functions: 91.66,
     },
   },

--- a/packages/network-of-terms-catalog/src/getCatalog.ts
+++ b/packages/network-of-terms-catalog/src/getCatalog.ts
@@ -10,7 +10,6 @@ import {
   Dataset,
   Feature,
   FeatureType,
-  IRI,
   Organization,
   SparqlDistribution,
 } from '@netwerk-digitaal-erfgoed/network-of-terms-query';
@@ -119,24 +118,24 @@ export async function fromStore(store: RDF.Store): Promise<Catalog> {
     datasets.map(
       dataset =>
         new Dataset(
-          new IRI(dataset.$id),
+          dataset.$id,
           dataset.name,
           dataset.description,
-          dataset.genres.map(genre => new IRI(genre)),
-          [new IRI(dataset.url)],
+          dataset.genres,
+          [dataset.url],
           dataset.mainEntityOfPage,
           dataset.inLanguage,
           [
             new Organization(
-              new IRI(dataset.creator.$id),
+              dataset.creator.$id,
               dataset.creator.name,
               dataset.creator.alternateName
             ),
           ],
           [
             new SparqlDistribution(
-              new IRI(dataset.distribution.$id),
-              new IRI(dataset.distribution.contentUrl),
+              dataset.distribution.$id,
+              dataset.distribution.contentUrl,
               dataset.distribution.potentialAction.filter(action =>
                 action.types.includes(schema.SearchAction)
               )[0].query!,

--- a/packages/network-of-terms-catalog/test/catalog.test.ts
+++ b/packages/network-of-terms-catalog/test/catalog.test.ts
@@ -2,7 +2,6 @@ import {
   Catalog,
   Dataset,
   FeatureType,
-  IRI,
   SparqlDistribution,
 } from '@netwerk-digitaal-erfgoed/network-of-terms-query';
 import {fromFile, fromStore, getCatalog} from '../src/index.js';
@@ -26,11 +25,11 @@ describe('Catalog', () => {
 
   it('can retrieve datasets by IRI', () => {
     expect(
-      catalog.getDatasetByDistributionIri(new IRI('https://nope.com'))
+      catalog.getDatasetByDistributionIri('https://nope.com')
     ).toBeUndefined();
 
     const cht = catalog.getDatasetByIri(
-      new IRI('https://data.cultureelerfgoed.nl/term/id/cht')
+      'https://data.cultureelerfgoed.nl/term/id/cht'
     )!;
     expect(cht).toBeInstanceOf(Dataset);
     expect(cht.name.nl).toEqual('Cultuurhistorische Thesaurus');
@@ -38,12 +37,10 @@ describe('Catalog', () => {
       'Onderwerpen voor het beschrijven van cultureel erfgoed'
     );
     expect(cht.genres).toContainEqual(
-      new IRI(
-        'https://data.cultureelerfgoed.nl/termennetwerk/onderwerpen/Abstracte-begrippen'
-      )
+      'https://data.cultureelerfgoed.nl/termennetwerk/onderwerpen/Abstracte-begrippen'
     );
     expect(cht.termsPrefixes).toEqual([
-      new IRI('https://data.cultureelerfgoed.nl/term/id/cht/'),
+      'https://data.cultureelerfgoed.nl/term/id/cht/',
     ]);
     expect(cht.alternateName.nl).toEqual('CHT');
     expect(cht.inLanguage).toEqual(['en', 'nl']);
@@ -60,29 +57,21 @@ describe('Catalog', () => {
   });
 
   it('can retrieve distributions by IRI', () => {
-    const distributionIri = new IRI(
-      'https://query.wikidata.org/sparql#entities-all'
-    );
+    const distributionIri = 'https://query.wikidata.org/sparql#entities-all';
     const wikidata = catalog.getDatasetByDistributionIri(distributionIri)!;
     const distribution = wikidata.getDistributionByIri(distributionIri)!;
     expect(distribution).toBeInstanceOf(SparqlDistribution);
     expect(distribution.iri).toEqual(distributionIri);
-    expect(distribution.endpoint).toEqual(
-      new IRI('https://query.wikidata.org/sparql')
-    );
+    expect(distribution.endpoint).toEqual('https://query.wikidata.org/sparql');
     expect(distribution.searchQuery).toMatch(/CONSTRUCT/);
     expect(distribution.lookupQuery).toMatch(/CONSTRUCT/);
   });
 
   it('can retrieve dataset by term IRI', () => {
-    expect(
-      catalog.getDatasetByTermIri(new IRI('https://nope'))
-    ).toBeUndefined();
-    const rkd = catalog.getDatasetByTermIri(
-      new IRI('https://data.rkd.nl/artists/123')
-    );
+    expect(catalog.getDatasetByTermIri('https://nope')).toBeUndefined();
+    const rkd = catalog.getDatasetByTermIri('https://data.rkd.nl/artists/123');
     expect(rkd).toBeInstanceOf(Dataset);
-    expect(rkd?.iri).toEqual(new IRI('https://data.rkd.nl/rkdartists'));
+    expect(rkd?.iri).toEqual('https://data.rkd.nl/rkdartists');
   });
 
   it('retrieves distributions providing feature', () => {
@@ -103,9 +92,8 @@ describe('Catalog', () => {
       )
     );
     const catalog = await fromStore(store);
-    const distributionIri = new IRI(
-      'https://data.beeldengeluid.nl/id/datadownload/0027'
-    );
+    const distributionIri =
+      'https://data.beeldengeluid.nl/id/datadownload/0027';
     const dataset = catalog.getDatasetByDistributionIri(distributionIri)!;
     expect(
       dataset.getDistributionByIri(distributionIri)?.endpoint.toString()

--- a/packages/network-of-terms-cli/src/query.ts
+++ b/packages/network-of-terms-cli/src/query.ts
@@ -5,7 +5,6 @@ import {
   DistributionsService,
   Error,
   getCliLogger,
-  IRI,
   QueryMode,
   Term,
   TermsResponse,
@@ -98,7 +97,7 @@ export class QuerySourcesCommand extends Command {
     const {flags} = await this.parse(QuerySourcesCommand);
     const sources = flags.uris
       .split(',')
-      .map((distributionId: string) => new IRI(distributionId.trim()));
+      .map((distributionId: string) => distributionId.trim());
 
     const logger = getCliLogger({
       name: 'cli',

--- a/packages/network-of-terms-graphql/src/resolvers.ts
+++ b/packages/network-of-terms-graphql/src/resolvers.ts
@@ -8,7 +8,6 @@ import {
   Error,
   Feature,
   FeatureType,
-  IRI,
   LookupQueryResult,
   LookupResult,
   LookupService,
@@ -56,7 +55,7 @@ async function queryTerms(
     comunica: context.comunica,
   });
   const results = await service.queryAll({
-    sources: args.sources.map((datasetIri: string) => new IRI(datasetIri)),
+    sources: args.sources,
     query: args.query,
     queryMode: QueryMode[args.queryMode as keyof typeof QueryMode],
     limit: args.limit,
@@ -76,10 +75,7 @@ async function lookupTerms(object: any, args: any, context: any) {
     context.catalog,
     new QueryTermsService({comunica: context.comunica, logger: context.app.log})
   );
-  const results = await service.lookup(
-    args.uris.map((iri: string) => new IRI(iri)),
-    args.timeoutMs
-  );
+  const results = await service.lookup(args.uris, args.timeoutMs);
 
   return results.map((result: LookupQueryResult) => {
     return {

--- a/packages/network-of-terms-graphql/test/server.test.ts
+++ b/packages/network-of-terms-graphql/test/server.test.ts
@@ -6,6 +6,7 @@ import {
   testCatalog,
   teardown,
 } from '../../network-of-terms-query/src/server-test.js';
+import {IRI} from '@netwerk-digitaal-erfgoed/network-of-terms-query';
 
 let httpServer: FastifyInstance;
 const catalog = testCatalog(3000);
@@ -295,7 +296,7 @@ function termsQuery({
   limit = 100,
   languages,
 }: {
-  sources: string[];
+  sources: IRI[];
   query?: string;
   limit?: number;
   languages?: string[];

--- a/packages/network-of-terms-query/src/catalog.ts
+++ b/packages/network-of-terms-query/src/catalog.ts
@@ -154,4 +154,4 @@ export enum FeatureType {
  */
 export type Distribution = SparqlDistribution;
 
-export class IRI extends URL {}
+export type IRI = string;

--- a/packages/network-of-terms-query/src/distributions.ts
+++ b/packages/network-of-terms-query/src/distributions.ts
@@ -30,11 +30,11 @@ const schemaBase = Joi.object({
 });
 
 const schemaQuery = schemaBase.append({
-  source: Joi.object().required(),
+  source: Joi.string().required(),
 });
 
 const schemaQueryAll = schemaBase.append({
-  sources: Joi.array().items(Joi.object().required()).min(1).required(),
+  sources: Joi.array().items(Joi.string().required()).min(1).required(),
 });
 
 export class DistributionsService {

--- a/packages/network-of-terms-query/src/server-test.ts
+++ b/packages/network-of-terms-query/src/server-test.ts
@@ -3,7 +3,6 @@ import {
   Dataset,
   Feature,
   FeatureType,
-  IRI,
   Organization,
   SparqlDistribution,
 } from './index.js';
@@ -20,32 +19,26 @@ let servers: SpawndChildProcess[];
 export const testCatalog = (port: number) =>
   new Catalog([
     new Dataset(
-      new IRI('https://data.rkd.nl/rkdartists'),
+      'https://data.rkd.nl/rkdartists',
       {nl: 'RKDartists', en: 'RKDartists'},
       {
         nl: 'Biografische gegevens van Nederlandse en buitenlandse kunstenaars van de middeleeuwen tot heden',
       },
-      [
-        new IRI(
-          'https://data.cultureelerfgoed.nl/termennetwerk/onderwerpen/Personen'
-        ),
-      ],
-      [new IRI('https://example.com/resources/')],
+      ['https://data.cultureelerfgoed.nl/termennetwerk/onderwerpen/Personen'],
+      ['https://example.com/resources/'],
       'https://example.com/rkdartists',
       ['en', 'nl'],
       [
         new Organization(
-          new IRI('https://rkd.nl'),
+          'https://rkd.nl',
           {nl: 'RKD – Nederlands Instituut voor Kunstgeschiedenis'},
           {nl: 'RKD'}
         ),
       ],
       [
         new SparqlDistribution(
-          new IRI(
-            'https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql'
-          ),
-          new IRI(`http://localhost:${port}/sparql`),
+          'https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql',
+          `http://localhost:${port}/sparql`,
           `
           PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
           CONSTRUCT { 
@@ -107,28 +100,26 @@ export const testCatalog = (port: number) =>
       {nl: 'RKD'}
     ),
     new Dataset(
-      new IRI('https://data.cultureelerfgoed.nl/term/id/cht'),
+      'https://data.cultureelerfgoed.nl/term/id/cht',
       {nl: 'Cultuurhistorische Thesaurus'},
       {nl: 'Onderwerpen voor het beschrijven van cultureel erfgoed'},
       [
-        new IRI(
-          'https://data.cultureelerfgoed.nl/termennetwerk/onderwerpen/Abstracte-begrippen'
-        ),
+        'https://data.cultureelerfgoed.nl/termennetwerk/onderwerpen/Abstracte-begrippen',
       ],
-      [new IRI('https://data.cultureelerfgoed.nl/term/id/cht/')],
+      ['https://data.cultureelerfgoed.nl/term/id/cht/'],
       'https://example.com/cht',
       ['nl'],
       [
         new Organization(
-          new IRI('https://www.cultureelerfgoed.nl'),
+          'https://www.cultureelerfgoed.nl',
           {nl: 'Rijksdienst voor het Cultureel Erfgoed'},
           {nl: 'RCE'}
         ),
       ],
       [
         new SparqlDistribution(
-          new IRI('https://example.com/distributions/endpoint-error'),
-          new IRI('http://does-not-resolve'),
+          'https://example.com/distributions/endpoint-error',
+          'http://does-not-resolve',
           'CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }',
           'CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }',
           [
@@ -141,60 +132,54 @@ export const testCatalog = (port: number) =>
       ]
     ),
     new Dataset(
-      new IRI('http://vocab.getty.edu/aat'),
+      'http://vocab.getty.edu/aat',
       {nl: 'Art & Architecture Thesaurus'},
       {
         nl: 'Onderwerpen voor het beschrijven van architectuur-, kunst- en cultuurhistorische collecties',
       },
       [
-        new IRI(
-          'https://data.cultureelerfgoed.nl/termennetwerk/onderwerpen/Abstracte-begrippen'
-        ),
+        'https://data.cultureelerfgoed.nl/termennetwerk/onderwerpen/Abstracte-begrippen',
       ],
-      [new IRI('http://vocab.getty.edu/aat/')],
+      ['http://vocab.getty.edu/aat/'],
       'https://example.com/aat',
       ['nl'],
       [
         new Organization(
-          new IRI('http://www.getty.edu/research/'),
+          'http://www.getty.edu/research/',
           {nl: 'Getty Research Institute'},
           {nl: 'Getty'}
         ),
       ],
       [
         new SparqlDistribution(
-          new IRI('https://example.com/distributions/timeout'),
-          new IRI('https://httpbin.org/delay/3'),
+          'https://example.com/distributions/timeout',
+          'https://httpbin.org/delay/3',
           'CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }',
           'CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }'
         ),
       ]
     ),
     new Dataset(
-      new IRI('http://data.beeldengeluid.nl/gtaa/Persoonsnamen'),
+      'http://data.beeldengeluid.nl/gtaa/Persoonsnamen',
       {nl: 'GTAA: persoonsnamen'},
       {nl: 'Personen voor het beschrijven van audiovisueel materiaal'},
       [
-        new IRI(
-          'https://data.cultureelerfgoed.nl/termennetwerk/onderwerpen/Abstracte-begrippen'
-        ),
+        'https://data.cultureelerfgoed.nl/termennetwerk/onderwerpen/Abstracte-begrippen',
       ],
-      [new IRI('http://data.beeldengeluid.nl/gtaa/')],
+      ['http://data.beeldengeluid.nl/gtaa/'],
       'https://example.com/gtaa',
       ['nl'],
       [
         new Organization(
-          new IRI('https://www.beeldengeluid.nl/'),
+          'https://www.beeldengeluid.nl/',
           {nl: 'Nederlands Instituut voor Beeld en Geluid'},
           {nl: 'Beeld en Geluid'}
         ),
       ],
       [
         new SparqlDistribution(
-          new IRI('https://data.beeldengeluid.nl/id/datadownload/0026'),
-          new IRI(
-            'https://username:password@gtaa.apis.beeldengeluid.nl/sparql'
-          ),
+          'https://data.beeldengeluid.nl/id/datadownload/0026',
+          'https://username:password@gtaa.apis.beeldengeluid.nl/sparql',
           'CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }',
           'CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }'
         ),

--- a/packages/network-of-terms-query/test/query.test.ts
+++ b/packages/network-of-terms-query/test/query.test.ts
@@ -1,5 +1,5 @@
 import {testCatalog} from '../src/server-test.js';
-import {IRI, QueryMode, QueryTermsService} from '../src/index.js';
+import {QueryMode, QueryTermsService} from '../src/index.js';
 import {QueryEngine} from '@comunica/query-sparql';
 import {ArrayIterator} from 'asynciterator';
 import {jest} from '@jest/globals';
@@ -22,7 +22,7 @@ describe('Query', () => {
   });
   it('passes dataset IRI query parameter to Comunica', async () => {
     const config = await query(
-      new IRI('https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql')
+      'https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql'
     );
     expect(config.initialBindings.get('datasetUri')?.value).toEqual(
       'https://data.rkd.nl/rkdartists'
@@ -31,7 +31,7 @@ describe('Query', () => {
 
   it('supports HTTP authentication', async () => {
     const config = await query(
-      new IRI('https://data.beeldengeluid.nl/id/datadownload/0026')
+      'https://data.beeldengeluid.nl/id/datadownload/0026'
     );
 
     // Must not contain credentials in URL...
@@ -43,7 +43,7 @@ describe('Query', () => {
   });
 });
 
-const query = async (iri: IRI) => {
+const query = async (iri: string) => {
   const dataset = catalog.getDatasetByDistributionIri(iri)!;
   await service.search(
     'van gogh',

--- a/packages/network-of-terms-reconciliation/src/server.ts
+++ b/packages/network-of-terms-reconciliation/src/server.ts
@@ -10,7 +10,6 @@ import nl from './locales/nl.json' with {type: 'json'};
 import {
   Catalog,
   getHttpLogger,
-  IRI,
   LookupService,
   QueryTermsService,
 } from '@netwerk-digitaal-erfgoed/network-of-terms-query';
@@ -55,7 +54,7 @@ export async function server(
   });
 
   server.get<{Params: {'*': string}}>('/reconcile/*', (request, reply) => {
-    const dataset = new IRI(request.params['*']);
+    const dataset = request.params['*'];
     const manifest = findManifest(dataset, catalog, request.root);
     if (manifest === undefined) {
       reply.code(404).send();
@@ -78,24 +77,20 @@ export async function server(
       // BC for Reconciliation API spec 0.2.
       if (request.body.ids) {
         await extendQuery(
-          (request.body as DataExtensionQuery).ids.map(
-            termIri => new IRI(termIri)
-          ),
+          (request.body as DataExtensionQuery).ids.map(termIri => termIri),
           lookupService,
           request.preferredLanguage
         );
         reply.send(
           await extendQuery(
-            (request.body as DataExtensionQuery).ids.map(
-              termIri => new IRI(termIri)
-            ),
+            (request.body as DataExtensionQuery).ids.map(termIri => termIri),
             lookupService,
             request.preferredLanguage
           )
         );
         return;
       }
-      const dataset = new IRI(request.params['*']);
+      const dataset = request.params['*'];
       const manifest = findManifest(dataset, catalog, request.root);
       if (manifest === undefined) {
         reply.code(404).send();
@@ -131,7 +126,7 @@ export async function server(
     async (request, reply) => {
       reply.send(
         await extendQuery(
-          request.body.ids.map(termIri => new IRI(termIri)),
+          request.body.ids,
           lookupService,
           request.preferredLanguage
         )
@@ -140,7 +135,7 @@ export async function server(
   );
 
   server.get<{Params: {'*': string}}>('/preview/*', async (request, reply) => {
-    const termIri = new IRI(request.params['*']);
+    const termIri = request.params['*'];
     const [lookupResult] = await lookupService.lookup([termIri], 10000);
     const source = catalog.getDatasetByDistributionIri(
       lookupResult.distribution.iri


### PR DESCRIPTION
* Replace the IRI class, which extended URL, with a simple type as alias for string.

Ref netwerk-digitaal-erfgoed/dataset-knowledge-graph#145

BREAKING CHANGE: all URIs are now typed IRI, an alias for string.