### PR TITLE
fix: correct URL for Canon van Limburg

### DIFF
--- a/packages/catalog/catalog/datasets/canon-van-limburg.jsonld
+++ b/packages/catalog/catalog/datasets/canon-van-limburg.jsonld
@@ -35,7 +35,7 @@
     }
   ],
   "url": [
-    "https://www.canonvannederland.nl"
+    "https://www.canonvannederland.nl/id/"
   ],
   "mainEntityOfPage": [
     "https://www.canonvannederland.nl/nl/limburg/limburg-nieuw/colofon"


### PR DESCRIPTION
Problem: we are only interested in the Canon van
Limburg for this source, not the entire Canon van
Nederland. However, the url pointed to
the Canon van Limburg landing page of the
Canon van Nederland site. That breaks the reverse
lookup functionality. Also broader and related
terms won't be found.

Fix: We change the url to point to the Canon van
Nederland. Also we change the source URI so it's
clear this is just a subset of the Canon van
Nederland. We use a fragment identifier to
indicate this is the Limburg subset, following
the pattern that was used for Wikidata subsets. 

--> tested this locally and it works. However, 
no labels are present in the graph for broader 
and related terms. We could add these in the
data.

Note: In the future we need to be aware that
reverse lookups will probably happen on the first
term source with the Canon van Nederland url
found. So if we add more subsets of the
Canon van Nederland, we need to take care
of that.