### PR TITLE
build(deps): group vitest packages in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,7 @@ updates:
       opentelemetry:
         patterns:
           - '@opentelemetry/*'
+      vitest:
+        patterns:
+          - '@vitest/*'
+          - 'vitest'


### PR DESCRIPTION
## Summary
* Add vitest dependency group to batch `@vitest/*` and `vitest` updates together

This reduces PR noise by combining related vitest dependency updates into single PRs.