### PR TITLE
feat(catalog): search ABR by URI in addition to label

### DIFF
--- a/packages/catalog/catalog/queries/search/abr.rq
+++ b/packages/catalog/catalog/queries/search/abr.rq
@@ -24,7 +24,7 @@ WHERE {
 
             VALUES ?predicate { skos:prefLabel skos:altLabel skos:hiddenLabel }
 
-            FILTER(CONTAINS(LCASE(?label), LCASE(?query)))
+            FILTER(CONTAINS(LCASE(?label), LCASE(?query)) || CONTAINS(LCASE(STR(?uri)), LCASE(?query)))
 
         }
         #LIMIT#


### PR DESCRIPTION
## Summary
- Extend ABR search query to also match the search term against concept URIs
- Uses OR condition with short-circuit evaluation for better performance

## Changes
The FILTER clause now checks both the label and the URI:
```sparql
FILTER(CONTAINS(LCASE(?label), LCASE(?query)) || CONTAINS(LCASE(STR(?uri)), LCASE(?query)))
```