### PR TITLE
fix(catalog): optimize AAT queries to prevent timeout

### DIFF
--- a/packages/catalog/catalog/queries/search/aat-materials.rq
+++ b/packages/catalog/catalog/queries/search/aat-materials.rq
@@ -27,10 +27,9 @@ WHERE {
         aat:300388277 # English
     }
 
-    # Pre-filter by language BEFORE the expensive subquery (optimization for GraphDB query planner).
-    # Faster than FILTER(langMatches(...)): https://vocab.getty.edu/queries#Find_Terms_by_Language_Tag
+    # Pre-filter by language BEFORE the expensive subquery (based on Comunica query optimization).
     ?uri skosxl:prefLabel [
-        dcterms:language ?language ;
+        dcterms:language ?language ; # Faster than FILTER(langMatches(...)): https://vocab.getty.edu/queries#Find_Terms_by_Language_Tag
         skosxl:literalForm ?prefLabel
     ]
 

--- a/packages/catalog/catalog/queries/search/aat-processes-and-techniques.rq
+++ b/packages/catalog/catalog/queries/search/aat-processes-and-techniques.rq
@@ -27,10 +27,9 @@ WHERE {
         aat:300388277 # English
     }
 
-    # Pre-filter by language BEFORE the expensive subquery (optimization for GraphDB query planner).
-    # Faster than FILTER(langMatches(...)): https://vocab.getty.edu/queries#Find_Terms_by_Language_Tag
+    # Pre-filter by language BEFORE the expensive subquery (based on Comunica query optimization).
     ?uri skosxl:prefLabel [
-        dcterms:language ?language ;
+        dcterms:language ?language ; # Faster than FILTER(langMatches(...)): https://vocab.getty.edu/queries#Find_Terms_by_Language_Tag
         skosxl:literalForm ?prefLabel
     ]
 

--- a/packages/catalog/catalog/queries/search/aat-styles-and-periods.rq
+++ b/packages/catalog/catalog/queries/search/aat-styles-and-periods.rq
@@ -27,10 +27,9 @@ WHERE {
         aat:300388277 # English
     }
 
-    # Pre-filter by language BEFORE the expensive subquery (optimization for GraphDB query planner).
-    # Faster than FILTER(langMatches(...)): https://vocab.getty.edu/queries#Find_Terms_by_Language_Tag
+    # Pre-filter by language BEFORE the expensive subquery (based on Comunica query optimization).
     ?uri skosxl:prefLabel [
-        dcterms:language ?language ;
+        dcterms:language ?language ; # Faster than FILTER(langMatches(...)): https://vocab.getty.edu/queries#Find_Terms_by_Language_Tag
         skosxl:literalForm ?prefLabel
     ]
 

--- a/packages/catalog/catalog/queries/search/aat.rq
+++ b/packages/catalog/catalog/queries/search/aat.rq
@@ -27,10 +27,9 @@ WHERE {
         aat:300388277 # English
     }
 
-    # Pre-filter by language BEFORE the expensive subquery (optimization for GraphDB query planner).
-    # Faster than FILTER(langMatches(...)): https://vocab.getty.edu/queries#Find_Terms_by_Language_Tag
+    # Pre-filter by language BEFORE the expensive subquery (based on Comunica query optimization).
     ?uri skosxl:prefLabel [
-        dcterms:language ?language ;
+        dcterms:language ?language ; # Faster than FILTER(langMatches(...)): https://vocab.getty.edu/queries#Find_Terms_by_Language_Tag
         skosxl:literalForm ?prefLabel
     ]
 


### PR DESCRIPTION
## Summary

* Move language filter pattern before inner SELECT subquery to help GraphDB query planner
* Remove duplicate language pattern after subquery (was redundant)
* Fix variable scoping issue where `?language` from outer `VALUES` clause was not visible inside the subquery

## Background

The AAT queries were timing out (>15s) when sent directly to the Getty SPARQL endpoint. Investigation revealed that Comunica automatically rewrites queries to place constraining patterns before subqueries, which is why queries through the Network of Terms API worked while direct queries timed out.

By applying the same optimization pattern to the query files, they now complete in ~700ms.

## Test plan

- [x] Verify AAT searches return results without timeout
- [x] Test all four AAT distributions: aat, aat-materials, aat-processes-and-techniques, aat-styles-and-periods