### PR TITLE
fix: sync package versions with npm registry

### DIFF
--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netwerk-digitaal-erfgoed/network-of-terms-catalog",
-  "version": "10.16.0",
+  "version": "10.17.0",
   "description": "Catalog of Network of Terms datasets",
   "keywords": [
     "nde"

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netwerk-digitaal-erfgoed/network-of-terms-query",
-  "version": "6.2.8",
+  "version": "6.2.9",
   "description": "Engine for querying sources in the Network of Terms",
   "keywords": [],
   "homepage": "https://github.com/netwerk-digitaal-erfgoed/network-of-terms#readme",


### PR DESCRIPTION
## Summary

* Sync local package.json versions with what was published to npm
* catalog: 10.16.0 → 10.17.0
* query: 6.2.8 → 6.2.9

The version bump commits from previous releases were not pushed back to the repository, causing a mismatch between local versions and npm.