### PR TITLE
fix(release): enable GitHub releases by removing groups config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,6 @@ jobs:
         id: docker
         run: |
           npx nx release --dockerVersionScheme=production --yes
-          git push --follow-tags --no-verify --atomic
           {
             echo 'images<<EOF'
             docker image ls ghcr.io/netwerk-digitaal-erfgoed/network-of-terms-* --format "{{.Repository}}:{{.Tag}}"

--- a/nx.json
+++ b/nx.json
@@ -54,40 +54,29 @@
     }
   ],
   "release": {
-    "groups": {
-      "libs": {
-        "projects": ["network-of-terms-catalog", "network-of-terms-query"],
-        "projectsRelationship": "independent",
-        "version": {
-          "preVersionCommand": "npx nx run-many -t build --projects=packages/*",
-          "conventionalCommits": true,
-          "fallbackCurrentVersionResolver": "disk"
-        },
-        "changelog": {
-          "projectChangelogs": {
-            "createRelease": "github"
-          },
-          "automaticFromRef": true
-        }
-      },
-      "apps": {
-        "projects": [
-          "network-of-terms-graphql",
-          "network-of-terms-reconciliation"
-        ],
-        "projectsRelationship": "independent",
-        "releaseTagPattern": "release/{projectName}/{version}",
-        "docker": {
-          "skipVersionActions": true,
-          "registryUrl": "ghcr.io/netwerk-digitaal-erfgoed",
-          "versionSchemes": {
-            "production": "{currentDate|YYYYMMDDHHmm}-{shortCommitSha}"
-          }
-        }
+    "projects": [
+      "network-of-terms-catalog",
+      "network-of-terms-query",
+      "network-of-terms-graphql",
+      "network-of-terms-reconciliation"
+    ],
+    "projectsRelationship": "independent",
+    "docker": {
+      "registryUrl": "ghcr.io/netwerk-digitaal-erfgoed",
+      "versionSchemes": {
+        "production": "{versionActionsVersion}"
       }
     },
     "version": {
-      "preVersionCommand": "npx nx run-many -t build"
+      "preVersionCommand": "npx nx run-many -t build",
+      "conventionalCommits": true,
+      "fallbackCurrentVersionResolver": "disk"
+    },
+    "changelog": {
+      "projectChangelogs": {
+        "createRelease": "github"
+      },
+      "automaticFromRef": true
     }
   },
   "targetDefaults": {


### PR DESCRIPTION
## Summary

* Remove release groups in favor of flat project list to fix GitHub releases not being created
* Configure Docker to use semver tags via `{versionActionsVersion}` instead of timestamp tags
* Remove explicit git push from workflow as Nx handles it automatically

## What changes

| Before | After |
|--------|-------|
| Docker apps: timestamp tags (`202601291445-abc123`) | Docker apps: semver tags (`1.0.0`) |
| Groups block git push | No groups, push works |
| Groups block GitHub releases | No groups, releases work |

## Test plan

* [x] Verified with `npx nx release --dockerVersionScheme=production --skip-publish --dry-run`
* [ ] Verify GitHub releases are created after merge