### PR TITLE
fix(release): add updateDependents to fix tag creation for dependency bumps

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -70,7 +70,10 @@
     "version": {
       "preVersionCommand": "npx nx run-many -t build",
       "conventionalCommits": true,
-      "fallbackCurrentVersionResolver": "disk"
+      "fallbackCurrentVersionResolver": "disk",
+      "generatorOptions": {
+        "updateDependents": "auto"
+      }
     },
     "changelog": {
       "projectChangelogs": {


### PR DESCRIPTION
## Summary

* Add `generatorOptions.updateDependents: "auto"` to ensure dependent projects get proper version bumps
* Workaround for Nx bug where `{version}` placeholder isn't interpolated for dependency-only updates

## Context

The release workflow was failing with:
```
fatal: '@netwerk-digitaal-erfgoed/network-of-terms-catalog@{version}' is not a valid tag name.
```

This is a known Nx bug where projects that only have dependency updates (no direct code changes) don't get their version properly interpolated when creating git tags.

Related issues:
- https://github.com/nrwl/nx/issues/22798
- https://github.com/nrwl/nx/issues/22119

## Test plan

* [ ] Verify release workflow succeeds after merge