### PR TITLE
fix(release): use semver version for git tags instead of Docker version

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -61,6 +61,9 @@
       "network-of-terms-reconciliation"
     ],
     "projectsRelationship": "independent",
+    "releaseTag": {
+      "preferDockerVersion": false
+    },
     "docker": {
       "registryUrl": "ghcr.io/netwerk-digitaal-erfgoed",
       "versionSchemes": {


### PR DESCRIPTION
## Summary

* Add `releaseTag.preferDockerVersion: false` to nx.json to fix git tag creation failing with `{version}` placeholder.

## Problem

`nx release` was failing with:
```
fatal: '@netwerk-digitaal-erfgoed/network-of-terms-catalog@{version}' is not a valid tag name.
```

This is caused by [Nx bug #33890](https://github.com/nrwl/nx/issues/33890): when a `docker` configuration exists in `release`, Nx incorrectly tries to use `dockerVersion` for the `{version}` placeholder in git tag patterns.

## Solution

Add `releaseTag.preferDockerVersion: false` to explicitly use regular semver versions for git tags.

Based on [this fix](https://github.com/thdk/nx-monorepo-demo/commit/97a9cf7b436ce99b56da47ed58015de0dcc868bc).