### PR TITLE
fix(release): skip workflow on bot-authored commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Skip bot-authored commits to prevent redundant workflow runs.
+    if: github.event.head_commit.author.name != 'github-actions[bot]'
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

Skip the release workflow when the commit is authored by `github-actions[bot]` to prevent redundant workflow runs after automated release commits.

## Changes

* Add `if` condition to the release job that checks `github.event.head_commit.author.name`
* Skips execution when the author is `github-actions[bot]`

## Context

After `nx release` creates its "chore(release): publish" commit and pushes, the workflow would run again unnecessarily. This also avoids [Nx bug #33624](https://github.com/nrwl/nx/issues/33624) where empty version placeholders cause invalid Docker image tags.