### PR TITLE
fix(status): strip credentials from LDES monitored endpoint URLs

### DIFF
--- a/packages/status/src/ldes/serializer.ts
+++ b/packages/status/src/ldes/serializer.ts
@@ -6,6 +6,16 @@ import { sosa, ldes, tree, status, rdf, xsd } from './vocabulary.js';
 
 const { namedNode, literal, blankNode } = DataFactory;
 
+/**
+ * Remove credentials (username and password) from a URL string.
+ */
+function stripCredentials(urlString: string): string {
+  const url = new URL(urlString);
+  url.username = '';
+  url.password = '';
+  return url.toString();
+}
+
 export interface SerializerConfig {
   baseUrl: string;
 }
@@ -134,7 +144,7 @@ export class LdesSerializer {
     observationUri: ReturnType<typeof namedNode>,
   ): void {
     const datasetUri = namedNode(observation.datasetIri);
-    const endpointUri = namedNode(observation.endpointUrl);
+    const endpointUri = namedNode(stripCredentials(observation.endpointUrl));
     const resultNode = blankNode();
 
     // Observation type and properties

--- a/packages/status/test/serializer.test.ts
+++ b/packages/status/test/serializer.test.ts
@@ -135,5 +135,19 @@ describe('LdesSerializer', () => {
       // But no observation data
       expect(turtle).not.toContain('sosa/Observation');
     });
+
+    it('should strip credentials from endpoint URL', async () => {
+      const observations = [
+        createObservation({
+          endpointUrl: 'https://user:password@example.org/sparql',
+        }),
+      ];
+      const turtle = await streamToString(
+        serializer.serializeLatestView(observations, contentType),
+      );
+
+      expect(turtle).toContain('https://example.org/sparql');
+      expect(turtle).not.toContain('user:password');
+    });
   });
 });


### PR DESCRIPTION
## Summary
* Strip username and password credentials from endpoint URLs before including them in the LDES output
* Add `stripCredentials` helper function that uses the URL API to safely remove credentials
* Add test coverage for credential stripping

This prevents credentials from being exposed in the public `/observations/latest` endpoint.