### PR TITLE
refactor(release): use release groups and disable changelog files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,10 +51,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PAT }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
-          NX_VERBOSE_LOGGING: true
         id: docker
         run: |
-          npx nx release --dockerVersionScheme=production --yes
+          npx nx release --yes
           {
             echo 'images<<EOF'
             docker image ls ghcr.io/netwerk-digitaal-erfgoed/network-of-terms-* --format "{{.Repository}}:{{.Tag}}"

--- a/nx.json
+++ b/nx.json
@@ -54,23 +54,7 @@
     }
   ],
   "release": {
-    "projects": [
-      "network-of-terms-catalog",
-      "network-of-terms-query",
-      "network-of-terms-graphql",
-      "network-of-terms-reconciliation",
-      "network-of-terms-status"
-    ],
     "projectsRelationship": "independent",
-    "releaseTag": {
-      "preferDockerVersion": false
-    },
-    "docker": {
-      "registryUrl": "ghcr.io/netwerk-digitaal-erfgoed",
-      "versionSchemes": {
-        "production": "{versionActionsVersion}"
-      }
-    },
     "version": {
       "preVersionCommand": "npx nx run-many -t build",
       "conventionalCommits": true,
@@ -84,6 +68,31 @@
         }
       },
       "automaticFromRef": true
+    },
+    "groups": {
+      "packages": {
+        "projects": ["network-of-terms-catalog", "network-of-terms-query"],
+        "releaseTag": {
+          "pattern": "{projectName}@{version}"
+        }
+      },
+      "apps": {
+        "projects": [
+          "network-of-terms-graphql",
+          "network-of-terms-reconciliation",
+          "network-of-terms-status"
+        ],
+        "releaseTag": {
+          "pattern": "{projectName}@{version}"
+        },
+        "docker": {
+          "skipVersionActions": true,
+          "registryUrl": "ghcr.io/netwerk-digitaal-erfgoed",
+          "versionSchemes": {
+            "production": "{currentDate|YYYYMMDDHHmm}-{shortCommitSha}"
+          }
+        }
+      }
     }
   },
   "targetDefaults": {


### PR DESCRIPTION
## Summary

* Organize projects into 'packages' and 'apps' release groups
* Use timestamp-based Docker tags with `skipVersionActions` for apps
* Simplify workflow by removing verbose logging and `dockerVersionScheme` flag

## Problem

When using `{versionActionsVersion}` for Docker tags, `nx release` fails for apps without changes because the version is empty:

```
NX   Invalid semver version specifier "release" provided. Please provide either a valid semver version or a valid semver version keyword.
```

This is a [known issue](https://github.com/nrwl/nx/issues/30824) where `versionData` is empty when no projects have changes.

## Solution

Use timestamp-based Docker tags (`{currentDate|YYYYMMDDHHmm}-{shortCommitSha}`) with `skipVersionActions: true` for apps. This means:

- All apps get new Docker tags on every release (even unchanged ones)
- But: simple, reliable, no empty version errors

Apps get tags like `202601310655-bf664b0`, packages get proper semver tags for npm publishing.