### PR TITLE
fix(release): remove automaticFromRef to speed up changelog

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -66,8 +66,7 @@
         "renderOptions": {
           "includeCommitBody": true
         }
-      },
-      "automaticFromRef": true
+      }
     },
     "groups": {
       "packages": {


### PR DESCRIPTION
## Summary

* Remove `automaticFromRef: true` from changelog config

## Problem

The `automaticFromRef` setting caused `nx release` to scan the entire git history, resulting in:
- Slow release times
- Many warnings about removed packages (jest, gts, ts-jest, etc.)
- CI hanging during changelog generation

## Solution

Without this flag, Nx uses the last release tag as the starting point for changelog generation, which is the typical desired behavior.