### PR TITLE
fix(ci): add concurrency control to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 permissions:
   contents: write
   id-token: write # needed for provenance data generation


### PR DESCRIPTION
## Summary

- Add `concurrency` block to prevent race conditions when multiple commits push to master during a slow release
- Queue new release runs instead of cancelling in-progress ones

## Problem

The release workflow takes ~12 minutes. If another commit is pushed to master during that time (e.g. Dependabot), the release fails when trying to push:

```
! [rejected] master -> master (fetch first)
Updates were rejected because the remote contains work that you do not have locally
```

Example failure: https://github.com/netwerk-digitaal-erfgoed/network-of-terms/actions/runs/21567903310/job/62142246536

## Solution

With `cancel-in-progress: false`, new workflow runs wait in queue until the current release completes, ensuring the git push succeeds.