### PR TITLE
feat(catalog): optimize GeoNames search query

### DIFF
--- a/packages/catalog/catalog/queries/search/geonames.rq
+++ b/packages/catalog/catalog/queries/search/geonames.rq
@@ -14,28 +14,32 @@ CONSTRUCT {
 }
 WHERE {
     {
-        SELECT ?uri (MAX(?sc) as ?score) WHERE {
-            (?uri ?sc) text:query (gn:name gn:alternateName ?query) .
+        SELECT ?uri ?featureClass ?countryCode (MAX(?sc) as ?score) WHERE {
+            (?uri ?sc) text:query (gn:name gn:alternateName gn:countryCode ?query) .
             ?uri a gn:Feature ;
                 gn:featureClass ?featureClass ;
                 gn:countryCode ?countryCode .
             # Limit results to places (P), localities (L), administrative levels (A) and water surfaces (H).
             VALUES ?featureClass { gn:P gn:L gn:A gn:H }
-            # Optionally limit to specific countries based on the dataset.
-            FILTER(
-                ?datasetUri = <https://www.geonames.org>
-                || ?countryCode IN ("NL", "BE", "DE")
-            )
+            # Country filter from URI fragment (e.g. #NL-BE-DE), or allow all if no fragment
+            BIND(COALESCE(STRAFTER(STR(?datasetUri), "#"), "") AS ?countriesFragment)
+            FILTER(?countriesFragment = "" || CONTAINS(UCASE(?countriesFragment), ?countryCode))
         }
-        GROUP BY ?uri
+        GROUP BY ?uri ?featureClass ?countryCode
         ORDER BY DESC(?score)
         #LIMIT#
     }
 
-    ?uri gn:name ?prefLabel ;
-        gn:countryCode ?countryCode .
+    ?uri gn:name ?prefLabel .
 
     BIND(CONCAT(?prefLabel," (",UCASE(?countryCode),")") as ?prefLabel_ext)
+
+    VALUES (?featureClass ?scopeNote_en ?scopeNote_nl) {
+        (gn:A "Administrative boundary"@en "Bestuurlijke eenheid"@nl)
+        (gn:H "Hydrographic"@en "Water"@nl)
+        (gn:L "Area"@en "Gebied"@nl)
+        (gn:P "Populated place"@en "Plaats"@nl)
+    }
 
     OPTIONAL {
         ?uri gn:alternateName ?altLabel .
@@ -48,18 +52,5 @@ WHERE {
         VALUES ?parents { gn:parentADM1 gn:parentADM2 }
         # filter out the circular links in the converted data
         FILTER(?uri != ?broader)
-    }
-
-    ?uri gn:featureClass ?featureClass .
-    VALUES (?featureClass ?scopeNote_en ?scopeNote_nl) {
-        (gn:A "Administrative boundary"@en "Bestuurlijke eenheid"@nl)
-        (gn:H "Hydrographic"@en "Water"@nl)
-        (gn:L "Area"@en "Gebied"@nl)
-        (gn:P "Populated place"@en "Plaats"@nl)
-        (gn:R "Road/railroad"@en "Infrastructuur"@nl)
-        (gn:S "Spot"@en "Object"@nl)
-        (gn:T "Hypsographic"@en "Reliëf"@nl)
-        (gn:U "Undersea"@en "Onder water"@nl)
-        (gn:V "Vegetation"@en "Vegetatie"@nl)
     }
 }


### PR DESCRIPTION
## Summary

- Project `featureClass` and `countryCode` from subquery to avoid redundant property lookups in outer query
- Add `gn:countryCode` to `text:query` to enable country code search (e.g., "amsterdam nl")
- Replace hardcoded country filter with dynamic URI fragment parsing (`#NL-BE-DE`)
- Remove unused VALUES entries (R, S, T, U, V feature classes that can never match)

## Notes

For optimal country code search ranking, the Fuseki text index should be configured with (netwerk-digitaal-erfgoed/infrastructure#163)
- `countryCode` field using `KeywordTokenizer` (exact match)
- Boost of ~2.0 for `countryCode` to outrank alternateName matches

## Test plan

- [ ] Search "amsterdam" returns Amsterdam (NL) with high score
- [ ] Search "amsterdam nl" returns Amsterdam (NL) ranked above other matches
- [ ] Search with dataset URI fragment (e.g., `#NL-BE-DE`) filters to those countries
- [ ] Search without fragment returns all countries

Ref #1580