### PR TITLE
refactor(test): use explicit vitest imports instead of globals

### DIFF
--- a/packages/catalog/test/catalog.test.ts
+++ b/packages/catalog/test/catalog.test.ts
@@ -1,3 +1,4 @@
+import { beforeAll, describe, expect, it } from 'vitest';
 import {
   Catalog,
   Dataset,

--- a/packages/catalog/test/shacl.test.ts
+++ b/packages/catalog/test/shacl.test.ts
@@ -1,3 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+declare module 'vitest' {
+  interface Assertion {
+    toConform(): void;
+  }
+}
+
 import { JsonLdParser } from 'jsonld-streaming-parser';
 import * as fs from 'fs';
 import rdf from 'rdf-ext';

--- a/packages/catalog/test/vitest.d.ts
+++ b/packages/catalog/test/vitest.d.ts
@@ -1,7 +1,0 @@
-import 'vitest';
-
-declare module 'vitest' {
-  interface Matchers {
-    toConform(): unknown;
-  }
-}

--- a/packages/catalog/tsconfig.test.json
+++ b/packages/catalog/tsconfig.test.json
@@ -2,13 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./out-tsc/vitest",
-    "types": [
-      "vitest/globals",
-      "vitest/importMeta",
-      "vite/client",
-      "node",
-      "vitest"
-    ],
+    "types": ["vitest/importMeta", "vite/client", "node", "vitest"],
     "forceConsistentCasingInFileNames": true
   },
   "include": [

--- a/packages/catalog/vite.config.ts
+++ b/packages/catalog/vite.config.ts
@@ -6,10 +6,8 @@ export default defineConfig(() => ({
   plugins: [],
   test: {
     watch: false,
-    globals: true,
     environment: 'node',
     include: ['test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-    reporters: ['default'],
     testTimeout: 10_000,
     coverage: {
       enabled: true,

--- a/packages/graphql/test/server.test.ts
+++ b/packages/graphql/test/server.test.ts
@@ -7,7 +7,7 @@ import {
   testCatalog,
 } from '@netwerk-digitaal-erfgoed/network-of-terms-query/test-utils';
 import { IRI } from '@netwerk-digitaal-erfgoed/network-of-terms-query';
-import { afterAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 let httpServer: FastifyInstance;
 const catalog = testCatalog(3000);

--- a/packages/graphql/tsconfig.test.json
+++ b/packages/graphql/tsconfig.test.json
@@ -2,13 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./out-tsc/vitest",
-    "types": [
-      "vitest/globals",
-      "vitest/importMeta",
-      "vite/client",
-      "node",
-      "vitest"
-    ]
+    "types": ["vitest/importMeta", "vite/client", "node", "vitest"]
   },
   "include": [
     "vite.config.ts",

--- a/packages/query/test/search/query-mode.test.ts
+++ b/packages/query/test/search/query-mode.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { QueryMode, queryVariants } from '../../src/index.js';
 
 describe('Search query', () => {

--- a/packages/query/tsconfig.test.json
+++ b/packages/query/tsconfig.test.json
@@ -2,13 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./out-tsc/vitest",
-    "types": [
-      "vitest/globals",
-      "vitest/importMeta",
-      "vite/client",
-      "node",
-      "vitest"
-    ],
+    "types": ["vitest/importMeta", "vite/client", "node", "vitest"],
     "forceConsistentCasingInFileNames": true
   },
   "include": [

--- a/packages/query/vite.config.ts
+++ b/packages/query/vite.config.ts
@@ -6,10 +6,8 @@ export default defineConfig(() => ({
   plugins: [],
   test: {
     watch: false,
-    globals: true,
     environment: 'node',
     include: ['test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-    reporters: ['default'],
     coverage: {
       enabled: true,
       reporter: ['text'],

--- a/packages/reconciliation/test/score.test.ts
+++ b/packages/reconciliation/test/score.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { calculateMatchingScore } from '../src/score.js';
 
 describe('Score', () => {

--- a/packages/reconciliation/test/server.test.ts
+++ b/packages/reconciliation/test/server.test.ts
@@ -1,3 +1,4 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { FastifyInstance } from 'fastify';
 import { server } from '../src/server.js';
 import { ReconciliationQueryBatch } from '../src/query.js';

--- a/packages/reconciliation/tsconfig.test.json
+++ b/packages/reconciliation/tsconfig.test.json
@@ -2,13 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./out-tsc/vitest",
-    "types": [
-      "vitest/globals",
-      "vitest/importMeta",
-      "vite/client",
-      "node",
-      "vitest"
-    ],
+    "types": ["vitest/importMeta", "vite/client", "node", "vitest"],
     "forceConsistentCasingInFileNames": true
   },
   "include": [

--- a/packages/reconciliation/vite.config.ts
+++ b/packages/reconciliation/vite.config.ts
@@ -6,10 +6,8 @@ export default defineConfig(() => ({
   plugins: [],
   test: {
     watch: false,
-    globals: true,
     environment: 'node',
     include: ['test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-    reporters: ['default'],
     testTimeout: 10_000,
     coverage: {
       enabled: true,

--- a/packages/status/tsconfig.test.json
+++ b/packages/status/tsconfig.test.json
@@ -2,13 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./out-tsc/vitest",
-    "types": [
-      "vitest/globals",
-      "vitest/importMeta",
-      "vite/client",
-      "node",
-      "vitest"
-    ]
+    "types": ["vitest/importMeta", "vite/client", "node", "vitest"]
   },
   "include": [
     "vite.config.ts",

--- a/packages/status/vite.config.ts
+++ b/packages/status/vite.config.ts
@@ -6,10 +6,8 @@ export default defineConfig(() => ({
   plugins: [],
   test: {
     watch: false,
-    globals: true,
     environment: 'node',
     include: ['test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-    reporters: ['default'],
     coverage: {
       enabled: true,
       reporter: ['text'],


### PR DESCRIPTION
## Summary

- Disable vitest globals in favor of explicit imports (better practice)
- Remove `vitest/globals` from tsconfig.test.json types
- Add explicit vitest imports to all test files
- Remove vitest.d.ts and inline custom matcher type augmentation in shacl.test.ts
- Remove redundant `reporters: ['default']` config (it's the default)

This fixes the `@nx/dependency-checks` lint error that was blocking PR #1723 (Vitest v4 upgrade).

Fixes #1723