### PR TITLE
fix(catalog): move GeoNames country code matching from Lucene to SPARQL

### DIFF
--- a/packages/catalog/catalog/queries/search/geonames.rq
+++ b/packages/catalog/catalog/queries/search/geonames.rq
@@ -14,8 +14,8 @@ CONSTRUCT {
 }
 WHERE {
     {
-        SELECT ?uri ?featureClass ?countryCode (MAX(?sc) as ?score) WHERE {
-            (?uri ?sc) text:query (gn:name gn:alternateName gn:countryCode ?query) .
+        SELECT ?uri ?featureClass ?countryCode (MAX(?sc) + IF(CONTAINS(CONCAT(" ", LCASE(?query), " "), CONCAT(" ", LCASE(?countryCode), " ")), 2.0, 0) AS ?score) WHERE {
+            (?uri ?sc) text:query (gn:name gn:alternateName ?query) .
             ?uri a gn:Feature ;
                 gn:featureClass ?featureClass ;
                 gn:countryCode ?countryCode .


### PR DESCRIPTION
## Summary

- Remove `gn:countryCode` from the `text:query` predicate list in the GeoNames search query. Searching countryCode via Lucene caused queries with short country codes (e.g. "amsterdam us") to hang, as Lucene had to score all locations in that country.
- Add a SPARQL-level score boost (+2.0) when a 2-letter word in the user's query matches the result's country code. This handles queries like "dorp be" and "amsterdam us" without the Lucene performance penalty.

The corresponding infrastructure change (removing countryCode from the Fuseki text index) is in netwerk-digitaal-erfgoed/infrastructure.

## Test plan

- [ ] Search "amsterdam us" — should return quickly, with Amsterdam (US) ranked higher
- [ ] Search "dorp be" — Dorp (BE) should rank above Dorp (DE)
- [ ] Search "amsterdam" — should return all Amsterdams as before