### PR TITLE
fix(catalog): use Lucene query-time boosting for GeoNames name field

### DIFF
--- a/packages/catalog/catalog/queries/search/geonames.rq
+++ b/packages/catalog/catalog/queries/search/geonames.rq
@@ -14,8 +14,14 @@ CONSTRUCT {
 }
 WHERE {
     {
-        SELECT ?uri ?featureClass ?countryCode (MAX(?sc) + IF(CONTAINS(CONCAT(" ", LCASE(?query), " "), CONCAT(" ", LCASE(?countryCode), " ")), 2.0, 0) AS ?score) WHERE {
-            (?uri ?sc) text:query (gn:name gn:alternateName ?query) .
+        SELECT ?uri ?featureClass ?countryCode (MAX(?sc)
+            + IF(CONTAINS(CONCAT(" ", LCASE(?query), " "), CONCAT(" ", LCASE(?countryCode), " ")), 2.0, 0)
+            + IF(?countryCode = "NL", 1.5, IF(?countryCode = "BE", 1.0, IF(?countryCode = "DE", 0.5, 0)))
+            AS ?score) WHERE {
+            # Boost name matches (^3) above alternateName matches, using Lucene query-time boosting
+            # (text:boost in the Fuseki config is silently ignored since Lucene 7.0).
+            BIND(CONCAT("name:(", ?query, ")^3 alternateName:(", ?query, ")") AS ?luceneQuery)
+            (?uri ?sc) text:query (?luceneQuery) .
             ?uri a gn:Feature ;
                 gn:featureClass ?featureClass ;
                 gn:countryCode ?countryCode .


### PR DESCRIPTION
## Summary

- Use explicit Lucene `^3` boost on the `name` field via query-time syntax (`name:(query)^3 alternateName:(query)`) instead of the non-functional `text:boost` config property. Jena Text's `text:boost` is silently ignored: the property was never implemented in Jena's vocabulary, and Lucene removed index-time field boosting in version 7.0 (2017).
- Add graduated country boost to break ties between identically-scored results: NL (+1.5), BE (+1.0), DE (+0.5).

This ensures:
- Name matches rank above alternateName matches (e.g. "Middelburg (NL)" above "Elmhurst (US)" for "middelburg")
- Dutch results rank above Belgian, German, and other countries when text scores are equal (e.g. "Middelburg (NL)" above "Middelburg (BE)" above "Middelburg (ZA)")

## Test plan

- [ ] Search "middelburg" — Middelburg (NL) should rank first, then (BE), then (DE), then (ZA)
- [ ] Search "amsterdam" — should still return results as before
- [ ] Search "dorp be" — Dorp (BE) should rank above Dorp (DE)

Fix #1580