### PR TITLE
Exclude coverage directory from ESLint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,7 @@ export default [
   {
     ignores: [
       '**/dist',
+      '**/coverage',
       '**/vite.config.*.timestamp*',
       '**/vitest.config.*.timestamp*',
     ],


### PR DESCRIPTION
## Summary

- Add `**/coverage` to ESLint's global ignores in `eslint.config.mjs`

When lint and test targets run concurrently in CI, ESLint crashes trying to scan the `coverage/` directory that tests are still writing to:

```
Error: ENOENT: no such file or directory, scandir '.../packages/reconciliation/coverage'
```