### PR TITLE
build: add nightly Nx migrate workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,14 +11,12 @@ updates:
       interval: 'monthly'
     ignore:
       - dependency-name: 'jsonld-context-parser' # Must match the version that Comunica depends on: https://github.com/comunica/comunica/blob/master/packages/actor-rdf-parse-jsonld/package.json#L48
+      - dependency-name: 'nx' # Handled by the Nx migrate workflow, which also runs code migrations.
+      - dependency-name: '@nx/*' # Handled by the Nx migrate workflow, which also runs code migrations.
     groups:
       comunica:
         patterns:
           - '@comunica/*'
-      nx:
-        patterns:
-          - '@nx/*'
-          - 'nx'
       opentelemetry:
         patterns:
           - '@opentelemetry/*'

--- a/.github/workflows/nx-migrate.yml
+++ b/.github/workflows/nx-migrate.yml
@@ -1,0 +1,10 @@
+name: Nx migrate
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # Every night at 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  migrate:
+    uses: netwerk-digitaal-erfgoed/workflows/.github/workflows/nx-migrate.yml@main


### PR DESCRIPTION
## Summary

- Add a nightly GitHub Actions workflow that checks for newer Nx versions and, if available, runs `nx migrate` to update and open a PR automatically
- The workflow calls a reusable workflow from `netwerk-digitaal-erfgoed/workflows`, so other repos can reuse it
- Ignore `nx` and `@nx/*` in Dependabot since `nx migrate` handles these better (it also runs code migrations/codemods)

**Note:** the reusable workflow needs to be added to `netwerk-digitaal-erfgoed/workflows` separately.