### PR TITLE
fix: add regional archives to Wikidata organizations filter

### DIFF
--- a/packages/catalog/catalog/queries/search/wikidata-entities.rq
+++ b/packages/catalog/catalog/queries/search/wikidata-entities.rq
@@ -91,6 +91,7 @@ WHERE {
                     wd:Q207694,  # art museum
                     wd:Q7075,    # library
                     wd:Q166118,  # archives
+                    wd:Q27032392, # regional archives
                     wd:Q3152824, # cultural institution
                     wd:Q83405,   # factory
                     wd:Q178706   # institution


### PR DESCRIPTION
## Summary

- Add `wd:Q27032392` (regional archives) to the curated list of organization types in the Wikidata entities SPARQL query
- Regional archives is a subclass of archives (`Q166118`), which was already included but didn't cover its subclasses like `Q27032392`
- This ensures that entities such as [Regionaal Archief Nijmegen](https://www.wikidata.org/wiki/Q15881190) appear in Wikidata organisations search results

Ref #1598