### PR TITLE
fix(catalog): catch Wikidata organization subtypes via one-level subclass traversal

### DIFF
--- a/packages/catalog/catalog/queries/search/wikidata-entities.rq
+++ b/packages/catalog/catalog/queries/search/wikidata-entities.rq
@@ -78,8 +78,8 @@ WHERE {
                 # against a curated type list. This catches subtypes like "design
                 # agency" (subclass of "business") that Wikidata doesn’t redundantly
                 # tag with the parent class. Full traversal (wdt:P279*) from Q43229
-                # times out; without the curated list, noise (schools, mosques,
-                # newspapers, etc.) creeps in.
+                # times out; without the curated list, unrelated organization
+                # types (schools, newspapers, governments, etc.) creep in.
                 #
                 # Examples that should be found:
                 # - Studio Truly Truly (Q124355137): design agency → business


### PR DESCRIPTION
## Summary

- Use `wdt:P31/wdt:P279?` instead of `wdt:P31` in the Wikidata organizations filter, so items whose direct type is one subclass level below a listed type are also matched (e.g. "design agency" → "business")
- Replace Q207694 (art museum as building/space) with Q3196771 (art museum as institution), the correct sense for an organizations filter; with `wdt:P279?` this also catches subtypes like design museum and architectural museum
- Add Q27032392 (regional archives) to the type list
- Document examples of items that should be found in the query comments

Items like [Studio Truly Truly](https://www.wikidata.org/wiki/Q124355137), [Mountain Design](https://www.wikidata.org/wiki/Q124742720), [Studio Harris Blondman](https://www.wikidata.org/wiki/Q136324662), and [Nieuwe Instituut](https://www.wikidata.org/wiki/Q20888634) are now found. The curated type list is retained to prevent unrelated organization types (schools, newspapers, governments, etc.) from appearing.