### PR TITLE
fix(catalog): use HTTPS for AAT SPARQL endpoint

### DIFF
--- a/packages/catalog/catalog/datasets/aat-processes-and-techniques.jsonld
+++ b/packages/catalog/catalog/datasets/aat-processes-and-techniques.jsonld
@@ -51,7 +51,7 @@
     {
       "@id": "http://vocab.getty.edu/aat/sparql/processes-and-techniques",
       "@type": "DataDownload",
-      "contentUrl": "http://vocab.getty.edu/sparql",
+      "contentUrl": "https://vocab.getty.edu/sparql",
       "encodingFormat": "application/sparql-query",
       "potentialAction": [
         {

--- a/packages/catalog/catalog/datasets/aat-styles-and-periods.jsonld
+++ b/packages/catalog/catalog/datasets/aat-styles-and-periods.jsonld
@@ -54,7 +54,7 @@
     {
       "@id": "http://vocab.getty.edu/aat/sparql/styles-and-periods",
       "@type": "DataDownload",
-      "contentUrl": "http://vocab.getty.edu/sparql",
+      "contentUrl": "https://vocab.getty.edu/sparql",
       "encodingFormat": "application/sparql-query",
       "potentialAction": [
         {

--- a/packages/catalog/catalog/datasets/aat.jsonld
+++ b/packages/catalog/catalog/datasets/aat.jsonld
@@ -72,7 +72,7 @@
     {
       "@id": "http://vocab.getty.edu/aat/sparql",
       "@type": "DataDownload",
-      "contentUrl": "http://vocab.getty.edu/sparql",
+      "contentUrl": "https://vocab.getty.edu/sparql",
       "encodingFormat": "application/sparql-query",
       "potentialAction": [
         {


### PR DESCRIPTION
Three of the four AAT distributions in the catalog pointed at `http://vocab.getty.edu/sparql`. Getty 301-redirects HTTP to HTTPS, and the redirect drops the POST body, so Comunica saw an upstream error and the API returned `ServerError` for any AAT search. Only `aat-materials` worked because it was already on HTTPS.

Switch the remaining three (`aat`, `aat-styles-and-periods`, `aat-processes-and-techniques`) to `https://vocab.getty.edu/sparql`.

Fix #1848
