### PR TITLE
ci(nx-migrate): drive Nx upgrades through Dependabot grouped PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,11 @@ updates:
       interval: 'monthly'
     ignore:
       - dependency-name: 'jsonld-context-parser' # Must match the version that Comunica depends on: https://github.com/comunica/comunica/blob/master/packages/actor-rdf-parse-jsonld/package.json#L48
-      - dependency-name: 'nx' # Handled by the Nx migrate workflow, which also runs code migrations.
-      - dependency-name: '@nx/*' # Handled by the Nx migrate workflow, which also runs code migrations.
     groups:
+      nx: # Grouped so they bump together; the Nx migrate workflow runs code migrations on the resulting PR.
+        patterns:
+          - 'nx'
+          - '@nx/*'
       comunica:
         patterns:
           - '@comunica/*'

--- a/.github/workflows/nx-migrate.yml
+++ b/.github/workflows/nx-migrate.yml
@@ -1,9 +1,10 @@
 name: Nx migrate
 
 on:
-  schedule:
-    - cron: '0 6 * * *' # Every night at 06:00 UTC
-  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
 
 jobs:
   migrate:


### PR DESCRIPTION
## Summary

- Let Dependabot handle Nx version bumps (grouped) instead of the scheduled `nx-migrate` workflow.
- Re-trigger the `nx-migrate` reusable workflow on the resulting PR so code migrations run on top of Dependabot’s bump.

## Why

The cron-driven `nx-migrate` workflow has been failing on `ERESOLVE` in dataset-register, and the same brittle flow lives here. Dependabot already produces a coherent `package.json` + `package-lock.json` for a grouped bump, so wiring `nx-migrate` to run *on top of* its PR sidesteps the ERESOLVE entirely. The shared workflow rewrite that handles the new trigger model is in netwerk-digitaal-erfgoed/workflows#38.

## Changes

- `.github/dependabot.yml` – drop the `nx` / `@nx/*` ignore entries and add an `nx` group so Dependabot bumps the whole set together.
- `.github/workflows/nx-migrate.yml` – swap the schedule trigger for a `pull_request` trigger filtered to manifest changes. The reusable workflow gates internally on `dependabot[bot]` + the `dependabot/npm_and_yarn/nx-` head ref, so non-Dependabot PRs (and non-nx Dependabot PRs) are skipped without allocating a runner.

## Test plan

- [x] Merge alongside netwerk-digitaal-erfgoed/workflows#38.
- [ ] Wait for the next Dependabot `nx` group PR (monthly schedule) and verify:
  - [ ] The `nx-migrate` workflow runs only on that PR, not on unrelated dep bumps.
  - [ ] Any code migrations land as a follow-up commit on the same branch.
  - [ ] CI reruns on the follow-up commit (proves the app-token push works).
