### PR TITLE
fix(catalog): do not cache empty genre dereferences

### DIFF
--- a/packages/catalog/src/genre.ts
+++ b/packages/catalog/src/genre.ts
@@ -34,6 +34,12 @@ const doDereferenceGenre = async (genre: IRI): Promise<Genre> => {
   );
   const bindings = await data.toArray();
 
+  if (bindings.length === 0) {
+    // Treat as failure so callers don’t cache an empty name dictionary
+    // (e.g. when the upstream returns a non-RDF error page).
+    throw new Error(`No bindings returned for genre <${genre}>`);
+  }
+
   return new Genre(
     genre,
     bindings.reduce((acc: StringDictionary, binding) => {

--- a/packages/catalog/test/genre.test.ts
+++ b/packages/catalog/test/genre.test.ts
@@ -90,6 +90,27 @@ describe('dereferenceGenre', () => {
     expect(result).toBeNull();
   });
 
+  it('does not cache empty results when upstream returns no bindings', async () => {
+    queryBindingsMock.mockResolvedValue({
+      toArray: async () => mockBindings([]),
+    } as never);
+    const dereferenceGenre = await importGenre();
+
+    const result = await dereferenceGenre(genreIri);
+    expect(result).toBeNull();
+
+    // Recovery: upstream starts returning bindings on the next call.
+    queryBindingsMock.mockResolvedValue({
+      toArray: async () =>
+        mockBindings([{ language: 'nl', value: 'Testgenre' }]),
+    } as never);
+
+    const recovered = await dereferenceGenre(genreIri);
+    expect(recovered).not.toBeNull();
+    expect(recovered!.name.nl).toEqual('Testgenre');
+    expect(queryBindingsMock).toHaveBeenCalledTimes(2);
+  });
+
   it('keeps stale data when background refresh fails', async () => {
     const dereferenceGenre = await importGenre();
 


### PR DESCRIPTION
## Summary

When `data.cultureelerfgoed.nl` is unreachable or returns a non-RDF error page (e.g. an HTTP 502 with an HTML body), Comunica parses zero bindings without throwing. `doDereferenceGenre` previously returned a `Genre` with an empty `name` dictionary in that case, and `dereferenceGenre` then cached it for 24 h. The GraphQL resolver falls back to `"Unknown"` when the name dictionary doesn’t have the requested language, so every genre kept showing `"Unknown"` long after the upstream had recovered.

This change makes `doDereferenceGenre` throw when no bindings are returned. The existing `catch` in `dereferenceGenre` swallows the error, returns `null`, and — crucially — leaves the cache empty, so the next request retries against the (now healthy) upstream.

## Changes

- `packages/catalog/src/genre.ts`: throw when SPARQL returns zero bindings.
- `packages/catalog/test/genre.test.ts`: cover the no-bindings path and verify a subsequent successful dereference populates the cache.
