### PR TITLE
fix(catalog): resolve and find GeoNames features without a country code

### DIFF
--- a/packages/catalog/catalog/queries/lookup/geonames.rq
+++ b/packages/catalog/catalog/queries/lookup/geonames.rq
@@ -14,10 +14,12 @@ WHERE {
     VALUES ?uri { ?uris }
 
     ?uri a gn:Feature ;
-        gn:countryCode ?countryCode ;
         gn:name ?prefLabel .
 
-    BIND(CONCAT(?prefLabel," (",UCASE(?countryCode),")") as ?prefLabel_ext)
+    # Supranational features (continents and the planet) have no country code.
+    OPTIONAL { ?uri gn:countryCode ?countryCode . }
+
+    BIND(IF(BOUND(?countryCode), CONCAT(?prefLabel," (",UCASE(?countryCode),")"), ?prefLabel) as ?prefLabel_ext)
 
     OPTIONAL {
         ?uri gn:alternateName ?altLabel .

--- a/packages/catalog/catalog/queries/search/geonames.rq
+++ b/packages/catalog/catalog/queries/search/geonames.rq
@@ -15,21 +15,24 @@ CONSTRUCT {
 WHERE {
     {
         SELECT ?uri ?featureClass ?countryCode (MAX(?sc)
-            + IF(CONTAINS(CONCAT(" ", LCASE(?query), " "), CONCAT(" ", LCASE(?countryCode), " ")), 2.0, 0)
-            + IF(?countryCode = "NL", 1.5, IF(?countryCode = "BE", 1.0, IF(?countryCode = "DE", 0.5, 0)))
+            + IF(CONTAINS(CONCAT(" ", LCASE(?query), " "), CONCAT(" ", LCASE(COALESCE(?countryCode, "")), " ")), 2.0, 0)
+            + IF(COALESCE(?countryCode, "") = "NL", 1.5, IF(COALESCE(?countryCode, "") = "BE", 1.0, IF(COALESCE(?countryCode, "") = "DE", 0.5, 0)))
             AS ?score) WHERE {
             # Boost name matches (^3) above alternateName matches, using Lucene query-time boosting
             # (text:boost in the Fuseki config is silently ignored since Lucene 7.0).
             BIND(CONCAT("name:(", ?query, ")^3 alternateName:(", ?query, ")") AS ?luceneQuery)
             (?uri ?sc) text:query (?luceneQuery) .
             ?uri a gn:Feature ;
-                gn:featureClass ?featureClass ;
-                gn:countryCode ?countryCode .
+                gn:featureClass ?featureClass .
+            # Supranational features (continents and the planet) have no country code.
+            OPTIONAL { ?uri gn:countryCode ?countryCode . }
             # Limit results to places (P), localities (L), administrative levels (A) and water surfaces (H).
             VALUES ?featureClass { gn:P gn:L gn:A gn:H }
             # Country filter from URI fragment (e.g. #NL-BE-DE), or allow all if no fragment
             BIND(COALESCE(STRAFTER(STR(?datasetUri), "#"), "") AS ?countriesFragment)
-            FILTER(?countriesFragment = "" || CONTAINS(UCASE(?countriesFragment), ?countryCode))
+            # Country-less features stay in unscoped searches but are excluded from country-scoped ones:
+            # do not coalesce here, since CONTAINS(x, "") is always true.
+            FILTER(?countriesFragment = "" || (BOUND(?countryCode) && CONTAINS(UCASE(?countriesFragment), ?countryCode)))
         }
         GROUP BY ?uri ?featureClass ?countryCode
         ORDER BY DESC(?score)
@@ -38,7 +41,7 @@ WHERE {
 
     ?uri gn:name ?prefLabel .
 
-    BIND(CONCAT(?prefLabel," (",UCASE(?countryCode),")") as ?prefLabel_ext)
+    BIND(IF(BOUND(?countryCode), CONCAT(?prefLabel," (",UCASE(?countryCode),")"), ?prefLabel) as ?prefLabel_ext)
 
     VALUES (?featureClass ?scopeNote_en ?scopeNote_nl) {
         (gn:A "Administrative boundary"@en "Bestuurlijke eenheid"@nl)


### PR DESCRIPTION
## Problem

Features without a GeoNames `country code` – continents (e.g. [`6255146` Africa](https://sws.geonames.org/6255146/)), the planet ([`6295630` Earth](https://sws.geonames.org/6295630/)) and oceans – could neither be looked up nor found through the Network of Terms, even when present in the source data. Both queries **required** `gn:countryCode` and used it to build the display label, so a country-less feature never matched.

## Lookup query (`queries/lookup/geonames.rq`)

- Make `gn:countryCode` `OPTIONAL` so supranational features match.
- Fall back to the bare name for `skos:prefLabel` when no country code is present. Previously `CONCAT` with an unbound `?countryCode` produced an unbound `?prefLabel_ext`, dropping the preferred label entirely; it now renders e.g. `Africa` instead of a label-less concept.

## Search query (`queries/search/geonames.rq`)

- Make `gn:countryCode` `OPTIONAL`.
- **Scoring:** coalesce `?countryCode` to `""` in the country-name boost and the `NL`/`BE`/`DE` rank boosts, so an unbound value does not raise an error that voids `?score`.
- **Country filter:** guard explicitly with `BOUND(?countryCode)` rather than coalescing – `CONTAINS(x, "")` is always true, so a country-less feature would otherwise leak into a country-scoped (e.g. `#NL-BE-DE`) search. This keeps country-less features in unscoped searches and excludes them from scoped ones (Africa should not appear in an NL-only search).
- **Label:** same name-only fallback as lookup.

The `featureClass` filter (`VALUES ?featureClass { gn:P gn:L gn:A gn:H }`) needs no change – Africa (`gn:L`) and oceans (`gn:H`) already pass.

## Notes

Source-data side is handled separately in netwerk-digitaal-erfgoed/geonames-rdf#31 (make `gn:countryCode` OPTIONAL at generation time).

The catalog test suite mocks Comunica and the search query relies on Fuseki-specific `text:query`, so the country-scoped vs. unscoped behavior can’t be asserted in an in-memory unit test here; both queries are parse-validated and the existing catalog tests pass.

Fix #1867
