### PR TITLE
docs: highlight public documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Network of Terms
 
+[![Documentation](https://img.shields.io/badge/docs-docs.nde.nl-blue)](https://docs.nde.nl/services/network-of-terms)
+
 The Network of Terms is a **search engine for finding terms** in terminology sources (such as thesauri, classification
 systems and reference lists).
 
@@ -43,7 +45,7 @@ flowchart TD
 
 This README and the package READMEs cover **running, hosting and extending** the Network of Terms software: install steps, environment variables, the catalog data model, query authoring and the test suite.
 
-For **using** the Network of Terms – the GraphQL and Reconciliation APIs, the demonstrator, available terminology sources – see the public documentation at [docs.nde.nl/services/network-of-terms](https://docs.nde.nl/services/network-of-terms).
+For **using** the Network of Terms, including the GraphQL and Reconciliation APIs, the demonstrator and available terminology sources, see the public documentation at 📖 [docs.nde.nl/services/network-of-terms](https://docs.nde.nl/services/network-of-terms).
 
 ## Getting started
 


### PR DESCRIPTION
Makes the link to the public documentation at [docs.nde.nl/services/network-of-terms](https://docs.nde.nl/services/network-of-terms) more recognizable in the README:

- Add a documentation badge under the title, so readers spot the docs entry point at a glance.
- Add a 📖 emoji to the documentation link in the running text of the Documentation section.
- Reword that sentence to use “including” instead of an en-dash parenthetical.
