### PR TITLE
build(deps): bump @lde/distribution-monitor to 0.1.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9834,9 +9834,9 @@
       }
     },
     "node_modules/@lde/distribution-monitor": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@lde/distribution-monitor/-/distribution-monitor-0.1.11.tgz",
-      "integrity": "sha512-GhsS3XaZFsL2YAu8c37O7DFdDeyqRsjZemclxwuX3YLso2psT+WAYuHeZK5kJ3zQ0fWwiZdRlo/cpnMPBp+hqQ==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@lde/distribution-monitor/-/distribution-monitor-0.1.12.tgz",
+      "integrity": "sha512-UEIfCE9hQiZgm9+D0f/1BXBAM4yIlMMHiE3dISVphIWcFxBFhFgL5sP96sf5TT+wcRig18LcBeUojVZuz6JowQ==",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "0.7.7",
@@ -25220,7 +25220,7 @@
       "dependencies": {
         "@fastify/cors": "11.2.0",
         "@lde/dataset": "0.7.7",
-        "@lde/distribution-monitor": "0.1.11",
+        "@lde/distribution-monitor": "0.1.12",
         "@netwerk-digitaal-erfgoed/network-of-terms-catalog": "*",
         "@netwerk-digitaal-erfgoed/network-of-terms-query": "*",
         "@rdfjs/types": "2.0.1",

--- a/packages/status/package.json
+++ b/packages/status/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@fastify/cors": "11.2.0",
     "@lde/dataset": "0.7.7",
-    "@lde/distribution-monitor": "0.1.11",
+    "@lde/distribution-monitor": "0.1.12",
     "@netwerk-digitaal-erfgoed/network-of-terms-catalog": "*",
     "@netwerk-digitaal-erfgoed/network-of-terms-query": "*",
     "@rdfjs/types": "2.0.1",


### PR DESCRIPTION
Bumps `@lde/distribution-monitor` from `0.1.11` to `0.1.12`.

This pulls in the schema-reconciliation rework: `PostgresObservationStore.create()` now diffs the declared schema against the **live** database (via drizzle-kit's `pushSchema`) and applies only the delta. An already-provisioned database therefore issues **no DDL on startup** — no more re-attempting the `CREATE UNIQUE INDEX` on the `latest_observations` materialized view on every boot, which contributed to the multi-hour startup stall when that lock was contended. Real schema changes still apply automatically, so schema evolution is supported without a separate migration step.

Transitive `@lde/*` versions are unchanged (`@lde/dataset@0.7.7`, `@lde/distribution-probe@0.1.12`).

Validated: `build`, `typecheck`, and `test` pass for `network-of-terms-status`.
