### PR TITLE
build(deps): bump @lde/distribution-monitor to 0.1.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9834,9 +9834,9 @@
       }
     },
     "node_modules/@lde/distribution-monitor": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@lde/distribution-monitor/-/distribution-monitor-0.1.12.tgz",
-      "integrity": "sha512-UEIfCE9hQiZgm9+D0f/1BXBAM4yIlMMHiE3dISVphIWcFxBFhFgL5sP96sf5TT+wcRig18LcBeUojVZuz6JowQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@lde/distribution-monitor/-/distribution-monitor-0.1.13.tgz",
+      "integrity": "sha512-9r7dXS1zN2x5yYccmhMhBIRYGBUBw1wE7HwfzpHvsF+57h4y7DXAokOiAELzraykpBltpEOatntbhEhatLiXkw==",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "0.7.7",
@@ -25220,7 +25220,7 @@
       "dependencies": {
         "@fastify/cors": "11.2.0",
         "@lde/dataset": "0.7.7",
-        "@lde/distribution-monitor": "0.1.12",
+        "@lde/distribution-monitor": "0.1.13",
         "@netwerk-digitaal-erfgoed/network-of-terms-catalog": "*",
         "@netwerk-digitaal-erfgoed/network-of-terms-query": "*",
         "@rdfjs/types": "2.0.1",

--- a/packages/status/package.json
+++ b/packages/status/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@fastify/cors": "11.2.0",
     "@lde/dataset": "0.7.7",
-    "@lde/distribution-monitor": "0.1.12",
+    "@lde/distribution-monitor": "0.1.13",
     "@netwerk-digitaal-erfgoed/network-of-terms-catalog": "*",
     "@netwerk-digitaal-erfgoed/network-of-terms-query": "*",
     "@rdfjs/types": "2.0.1",


### PR DESCRIPTION
Bumps `@lde/distribution-monitor` from `0.1.12` to `0.1.13`, which sets `lock_timeout` (30s) and `statement_timeout` (60s) on the status database connection. A contended `REFRESH MATERIALIZED VIEW CONCURRENTLY` (or the boot-time index check) now fails fast and retries on the next cycle instead of hanging indefinitely on a lock — the residual lock-wait surface after the schema-reconciliation rework.

Transitive `@lde/*` unchanged (`@lde/dataset@0.7.7`, `@lde/distribution-probe@0.1.12`). Build/typecheck/test pass for `network-of-terms-status`.