### PR TITLE
build(deps): bump @lde/distribution-monitor to 0.1.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9834,9 +9834,9 @@
       }
     },
     "node_modules/@lde/distribution-monitor": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/@lde/distribution-monitor/-/distribution-monitor-0.1.13.tgz",
-      "integrity": "sha512-9r7dXS1zN2x5yYccmhMhBIRYGBUBw1wE7HwfzpHvsF+57h4y7DXAokOiAELzraykpBltpEOatntbhEhatLiXkw==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@lde/distribution-monitor/-/distribution-monitor-0.1.14.tgz",
+      "integrity": "sha512-QL1lWSCSGJvEH952iEhqQdCmKIBb/MGJ1A972wg824wUC7tMin35j6brAyRxLjJjmmVDF2538FvFFWBTGEPY3Q==",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "0.7.7",
@@ -25220,7 +25220,7 @@
       "dependencies": {
         "@fastify/cors": "11.2.0",
         "@lde/dataset": "0.7.7",
-        "@lde/distribution-monitor": "0.1.13",
+        "@lde/distribution-monitor": "0.1.14",
         "@netwerk-digitaal-erfgoed/network-of-terms-catalog": "*",
         "@netwerk-digitaal-erfgoed/network-of-terms-query": "*",
         "@rdfjs/types": "2.0.1",

--- a/packages/status/package.json
+++ b/packages/status/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@fastify/cors": "11.2.0",
     "@lde/dataset": "0.7.7",
-    "@lde/distribution-monitor": "0.1.13",
+    "@lde/distribution-monitor": "0.1.14",
     "@netwerk-digitaal-erfgoed/network-of-terms-catalog": "*",
     "@netwerk-digitaal-erfgoed/network-of-terms-query": "*",
     "@rdfjs/types": "2.0.1",


### PR DESCRIPTION
Bumps `@lde/distribution-monitor` from 0.1.13 to 0.1.14 in the status service.

0.1.14 makes the monitor tolerate a `55P03` (lock_not_available) on its boot-time `CREATE UNIQUE INDEX IF NOT EXISTS` against the `latest_observations` materialized view, instead of aborting startup. This fixes the production crash-loop where, during a rolling deploy, the new pod's index re-check timed out waiting on the old pod's `REFRESH … CONCURRENTLY` and the monitor never started — leaving the status site without availabilities.

Upstream PR: ldelements/lde#492
