### PR TITLE
build(deps): bump @lde/distribution-monitor to 0.1.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9834,9 +9834,9 @@
       }
     },
     "node_modules/@lde/distribution-monitor": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@lde/distribution-monitor/-/distribution-monitor-0.1.14.tgz",
-      "integrity": "sha512-QL1lWSCSGJvEH952iEhqQdCmKIBb/MGJ1A972wg824wUC7tMin35j6brAyRxLjJjmmVDF2538FvFFWBTGEPY3Q==",
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@lde/distribution-monitor/-/distribution-monitor-0.1.15.tgz",
+      "integrity": "sha512-81deVQOg5QDiHoSgc1f9b+eP97gK7iuMAM8DJY5QAcoLGAzBlVVXXAtkchD0kii5eo+Zg3joBPI3xVfPPo0pxg==",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "0.7.7",
@@ -25220,7 +25220,7 @@
       "dependencies": {
         "@fastify/cors": "11.2.0",
         "@lde/dataset": "0.7.7",
-        "@lde/distribution-monitor": "0.1.14",
+        "@lde/distribution-monitor": "0.1.15",
         "@netwerk-digitaal-erfgoed/network-of-terms-catalog": "*",
         "@netwerk-digitaal-erfgoed/network-of-terms-query": "*",
         "@rdfjs/types": "2.0.1",

--- a/packages/status/package.json
+++ b/packages/status/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@fastify/cors": "11.2.0",
     "@lde/dataset": "0.7.7",
-    "@lde/distribution-monitor": "0.1.14",
+    "@lde/distribution-monitor": "0.1.15",
     "@netwerk-digitaal-erfgoed/network-of-terms-catalog": "*",
     "@netwerk-digitaal-erfgoed/network-of-terms-query": "*",
     "@rdfjs/types": "2.0.1",


### PR DESCRIPTION
Bumps `@lde/distribution-monitor` from 0.1.14 to 0.1.15 in the status service.

0.1.15 replaces the `latest_observations` materialized view with a plain table that is upserted on every observation write, instead of a periodic `REFRESH … CONCURRENTLY`. This fixes the status page serving stale data: the refresh recomputed `DISTINCT ON (monitor)` over the entire `observations` history each cycle, which on the status DB's slow (HDD) volume took minutes, exceeded the connection's `statement_timeout`, and failed silently — so the latest-status view froze while fresh probes piled up unseen.

With the upsert, "latest per monitor" is always current at O(1) per probe, with no scan, no refresh, and no lock contention. The matview→table switch happens automatically on first boot; the table refills within one poll cycle.

Upstream PR: ldelements/lde#493
