### PR TITLE
ci: skip release when no release projects are affected

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,7 @@ jobs:
           # Release only affected projects: ‘nx release’ tags Docker images for
           # every project it processes, but the build step above only builds
           # images for affected projects.
-          RELEASE_PROJECTS=$(jq -r '[.release.groups[].projects[]] | join(",")' nx.json)
-          AFFECTED=$(npx nx show projects --affected --projects "$RELEASE_PROJECTS" --json | jq -r 'join(",")')
+          AFFECTED=$(npx nx show projects --affected --projects "tag:release:*" --json | jq -r 'join(",")')
           if [ -n "$AFFECTED" ]; then
             npx nx release --yes --projects="$AFFECTED"
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,16 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
         id: docker
         run: |
-          npx nx release --yes
+          # Release only affected projects: ‘nx release’ tags Docker images for
+          # every project it processes, but the build step above only builds
+          # images for affected projects.
+          RELEASE_PROJECTS=$(jq -r '[.release.groups[].projects[]] | join(",")' nx.json)
+          AFFECTED=$(npx nx show projects --affected --projects "$RELEASE_PROJECTS" --json | jq -r 'join(",")')
+          if [ -n "$AFFECTED" ]; then
+            npx nx release --yes --projects="$AFFECTED"
+          else
+            echo "No release projects affected; skipping release."
+          fi
           {
             echo 'images<<EOF'
             docker image ls ghcr.io/netwerk-digitaal-erfgoed/network-of-terms-* --format "{{.Repository}}:{{.Tag}}"

--- a/nx.json
+++ b/nx.json
@@ -72,7 +72,7 @@
     "groups": {
       "packages": {
         "projectsRelationship": "independent",
-        "projects": ["network-of-terms-catalog", "network-of-terms-query"],
+        "projects": ["tag:release:npm"],
         "releaseTag": {
           "pattern": "{projectName}@{version}"
         },
@@ -81,11 +81,7 @@
         }
       },
       "apps": {
-        "projects": [
-          "network-of-terms-graphql",
-          "network-of-terms-reconciliation",
-          "network-of-terms-status"
-        ],
+        "projects": ["tag:release:docker"],
         "releaseTag": {
           "pattern": "{projectName}@{version}"
         },

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -51,5 +51,8 @@
     "jsonld-streaming-parser": "5.0.1",
     "rdf-ext": "2.6.0",
     "rdf-validate-shacl": "0.6.5"
+  },
+  "nx": {
+    "tags": ["release:npm"]
   }
 }

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -33,6 +33,7 @@
     "node": ">=16.15.0"
   },
   "nx": {
+    "tags": ["release:docker"],
     "release": {
       "docker": {
         "repositoryName": "network-of-terms-graphql"

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -53,5 +53,8 @@
   "devDependencies": {
     "@comunica/query-sparql-file": "5.2.2",
     "asynciterator": "3.10.0"
+  },
+  "nx": {
+    "tags": ["release:npm"]
   }
 }

--- a/packages/reconciliation/package.json
+++ b/packages/reconciliation/package.json
@@ -34,6 +34,7 @@
     "accepts": "1.3.8"
   },
   "nx": {
+    "tags": ["release:docker"],
     "release": {
       "docker": {
         "repositoryName": "network-of-terms-reconciliation"

--- a/packages/status/package.json
+++ b/packages/status/package.json
@@ -35,6 +35,7 @@
     "node": ">=16.15.0"
   },
   "nx": {
+    "tags": ["release:docker"],
     "release": {
       "docker": {
         "repositoryName": "network-of-terms-status"


### PR DESCRIPTION
The [release run for b0d7a35](https://github.com/netwerk-digitaal-erfgoed/network-of-terms/actions/runs/28515535159/job/85247090476) failed with:

```
Command failed: docker tag packages-graphql ghcr.io/netwerk-digitaal-erfgoed/network-of-terms-graphql:20260705180405-b0d7a35
Error response from daemon: No such image: packages-graphql:latest
```

## Cause

The workflow builds Docker images with `nx affected -t docker:build`, but `npx nx release --yes` processes *every* project in the `apps` release group and unconditionally tags each app’s Docker image. Commit b0d7a35 only touched the workflow file, so no projects were affected, no images were built, and tagging failed.

Previous pushes happened to work because they were dependency bumps touching the root `package-lock.json`, which affects all projects. The failure was latent for partial builds too: a change touching only `packages/reconciliation` would have failed the same way on the unbuilt graphql image.

## Fix

Scope `nx release` to the affected release projects, and skip the release when there are none.

Release membership is now declared as Nx tags on the projects themselves – `release:npm` on the two published packages, `release:docker` on the three deployed apps. The release groups in `nx.json` reference those tags, and the workflow selects affected release projects with the nx-native `tag:release:*` pattern, so there is a single source of truth and no config parsing in the workflow.

This is safe because `nx release --projects` Docker-tags the filtered projects plus their dependents (verified against the Nx source and with dry-runs), and `nx affected` includes dependents as well – so every image the release tags is guaranteed to have been built by the preceding build step. The ‘Tag latest’ and ‘Deploy’ steps already skip themselves when no images exist.

Verified with local dry-runs:

- workflow-only commit → no affected release projects → release skipped
- dependency bump (all projects affected, stub images present) → all five projects released, three apps tagged, identical to current behaviour
- only reconciliation affected → only its image tagged; graphql/status untouched
