### PR TITLE
fix(catalog): prevent PoolParty query timeout on high-hit search terms

### DIFF
--- a/packages/catalog/catalog/queries/lookup/poolparty.rq
+++ b/packages/catalog/catalog/queries/lookup/poolparty.rq
@@ -23,39 +23,36 @@ WHERE {
 
     ?uri a skos:Concept .
 
-    OPTIONAL {
-        ?uri skos:prefLabel ?prefLabel .
-    }
-    OPTIONAL {
-        ?uri skos:altLabel ?altLabel .
-    }
-    OPTIONAL {
-        ?uri skos:hiddenLabel ?hiddenLabel .
-    }
-    OPTIONAL {
-        ?uri skos:scopeNote ?scopeNote .
-    }
-    OPTIONAL {
-        ?uri skos:definition ?scopeNote .
-    }
-    OPTIONAL {
-        ?uri skos:broader ?broader_uri .
-        ?broader_uri skos:prefLabel ?broader_prefLabel .
-    }
-    OPTIONAL {
-        ?uri skos:narrower ?narrower_uri .
-        ?narrower_uri skos:prefLabel ?narrower_prefLabel .
-    }
-    OPTIONAL {
-        ?uri skos:related ?related_uri .
-        ?related_uri skos:prefLabel ?related_prefLabel .
-    }
-    OPTIONAL {
-        ?uri skos:exactMatch ?exactMatch_uri .
-        FILTER(!STRSTARTS(STR(?exactMatch_uri), "https://data.cultureelerfgoed.nl/term/id/rn"))
-        FILTER(!STRSTARTS(STR(?exactMatch_uri), "https://data.cultureelerfgoed.nl/semnet"))
-        OPTIONAL {
-            ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
+    # Each property is independently multi-valued, so use UNION (one branch per
+    # property) instead of OPTIONAL to prevent a cross-product. Besides being
+    # far slower, the cross-product multiplies rows past the LIMIT below, which
+    # silently truncated related/narrower/broader labels of richly-linked
+    # concepts (e.g. ‘Transgender personen’, with 174 relations).
+    {
+        { ?uri skos:prefLabel ?prefLabel . }
+        UNION { ?uri skos:altLabel ?altLabel . }
+        UNION { ?uri skos:hiddenLabel ?hiddenLabel . }
+        UNION { ?uri skos:scopeNote ?scopeNote . }
+        UNION { ?uri skos:definition ?scopeNote . }
+        UNION {
+            ?uri skos:broader ?broader_uri .
+            ?broader_uri skos:prefLabel ?broader_prefLabel .
+        }
+        UNION {
+            ?uri skos:narrower ?narrower_uri .
+            ?narrower_uri skos:prefLabel ?narrower_prefLabel .
+        }
+        UNION {
+            ?uri skos:related ?related_uri .
+            ?related_uri skos:prefLabel ?related_prefLabel .
+        }
+        UNION {
+            ?uri skos:exactMatch ?exactMatch_uri .
+            FILTER(!STRSTARTS(STR(?exactMatch_uri), "https://data.cultureelerfgoed.nl/term/id/rn"))
+            FILTER(!STRSTARTS(STR(?exactMatch_uri), "https://data.cultureelerfgoed.nl/semnet"))
+            OPTIONAL {
+                ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
+            }
         }
     }
 }

--- a/packages/catalog/catalog/queries/search/poolparty.rq
+++ b/packages/catalog/catalog/queries/search/poolparty.rq
@@ -25,39 +25,34 @@ WHERE {
         }
         #LIMIT#
     }
-    OPTIONAL {
-        ?uri skos:prefLabel ?prefLabel .
-    }
-    OPTIONAL {
-        ?uri skos:altLabel ?altLabel .
-    }
-    OPTIONAL {
-        ?uri skos:hiddenLabel ?hiddenLabel .
-    }
-    OPTIONAL {
-        ?uri skos:scopeNote ?scopeNote .
-    }
-    OPTIONAL {
-        ?uri skos:definition ?scopeNote .
-    }
-    OPTIONAL {
-        ?uri skos:broader ?broader_uri .
-        ?broader_uri skos:prefLabel ?broader_prefLabel .
-    }
-    OPTIONAL {
-        ?uri skos:narrower ?narrower_uri .
-        ?narrower_uri skos:prefLabel ?narrower_prefLabel .
-    }
-    OPTIONAL {
-        ?uri skos:related ?related_uri .
-        ?related_uri skos:prefLabel ?related_prefLabel .
-    }
-    OPTIONAL {
-        ?uri skos:exactMatch ?exactMatch_uri .
-        FILTER(!STRSTARTS(STR(?exactMatch_uri), "https://data.cultureelerfgoed.nl/term/id/rn"))
-        FILTER(!STRSTARTS(STR(?exactMatch_uri), "https://data.cultureelerfgoed.nl/semnet"))
-        OPTIONAL {
-            ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
+    # Each property is independently multi-valued, so use UNION (one branch per
+    # property) instead of OPTIONAL to prevent a cross-product that multiplies
+    # the intermediate result set and times out on high-hit terms (e.g. ‘trans’).
+    {
+        { ?uri skos:prefLabel ?prefLabel . }
+        UNION { ?uri skos:altLabel ?altLabel . }
+        UNION { ?uri skos:hiddenLabel ?hiddenLabel . }
+        UNION { ?uri skos:scopeNote ?scopeNote . }
+        UNION { ?uri skos:definition ?scopeNote . }
+        UNION {
+            ?uri skos:broader ?broader_uri .
+            ?broader_uri skos:prefLabel ?broader_prefLabel .
+        }
+        UNION {
+            ?uri skos:narrower ?narrower_uri .
+            ?narrower_uri skos:prefLabel ?narrower_prefLabel .
+        }
+        UNION {
+            ?uri skos:related ?related_uri .
+            ?related_uri skos:prefLabel ?related_prefLabel .
+        }
+        UNION {
+            ?uri skos:exactMatch ?exactMatch_uri .
+            FILTER(!STRSTARTS(STR(?exactMatch_uri), "https://data.cultureelerfgoed.nl/term/id/rn"))
+            FILTER(!STRSTARTS(STR(?exactMatch_uri), "https://data.cultureelerfgoed.nl/semnet"))
+            OPTIONAL {
+                ?exactMatch_uri skos:prefLabel ?exactMatch_prefLabel .
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #1882

## Problem

A `search` against the Homosaurus source for high-hit terms like `trans` or `transgender` exceeds the query timeout, so the GraphQL `terms` query returns a `TimeoutError` member of the `TermsResult` union (`Source timed out after 5000ms`) instead of `Terms` — even though the underlying source (PoolParty / triple store) answers the same query fine. Lower-fanout terms like `homo` stay just under the timeout and succeed.

## Root cause

The shared PoolParty **search** and **lookup** query templates pulled in each independently multi-valued property (`skos:altLabel`, `skos:hiddenLabel`, `skos:broader`, `skos:narrower`, `skos:related`, `skos:exactMatch`, …) as a **separate `OPTIONAL`**. Multiple independent multi-valued `OPTIONAL`s multiply into a cross-product: a concept with, say, many altLabels × narrower × related × exactMatch explodes the intermediate result set. `trans`/`transgender` match many such richly-linked concepts; `homo` happened to stay just under the default 5000ms timeout.

Measured against the live Homosaurus SPARQL endpoint (`api.linkeddata.cultureelerfgoed.nl/.../homosaurus/sparql`):

| search term | before (OPTIONAL) | after (UNION) |
|------|------:|------:|
| homo | 3.4s | 0.24s |
| trans | **29.8s** ⛔ | 0.24s |
| transgender | **30.0s** ⛔ | 0.21s |

## Fix

Rewrote the property block in both templates as one `UNION` branch per property, so each branch binds only its own variable and no cross-product forms — the pattern recommended for CONSTRUCT queries with multiple independently multi-valued properties.

- **Search:** verified the rewrite returns an **identical set of triples** (`CONSTRUCT` dedups into a graph regardless), just ~100× faster — so the GraphQL `terms` response is unchanged, only the query no longer times out.
- **Lookup:** the cross-product there also multiplied rows past the existing `LIMIT 1000`, which **silently truncated** related/narrower/broader labels of hub concepts (e.g. the 174-relation *Transgender personen* concept returned 50 triples instead of 238). The UNION rewrite returns the complete set — so the `lookup` query gains correctness, not just speed.

## Scope

The templates are shared by 7 datasets, all of which benefit: **homosaurus, vrouwenthesaurus, rights, westerbork, koloniaal-verleden, wo2biografie, agrarische-thesaurus**.
