### PR TITLE
Resolve shared term-URI prefixes to the broadest dataset

### DIFF
--- a/packages/catalog/README.md
+++ b/packages/catalog/README.md
@@ -31,7 +31,9 @@ additions specific to the Network of Terms:
 
 - `schema:url` is used for the HTTP URI prefix of terms in the dataset, e.g. `http://vocab.getty.edu/aat/` for Getty
   resources. This prefix is needed when clients look up terms by their URI in the Network of Terms: the Network then has
-  to know which source to consult to retrieve the term;
+  to know which source to consult to retrieve the term. If the dataset is a subset of a broader dataset in the same URI
+  space (e.g. ‘Wikidata: persons’ is a subset of ‘Wikidata: all entities’), omit `schema:url`: only the
+  broadest dataset declares the prefix, so that lookups resolve to it rather than to an arbitrary subset;
 - `schema:inLanguage` is a required property;
 - `schema:genre` is a required property, with values restricted to the list of [Termennetwerk onderwerpen](https://data.cultureelerfgoed.nl/termennetwerk/onderwerpen.html);
 - `schema:mainEntityOfPage` is a required property;

--- a/packages/catalog/catalog/datasets/aat-materials.jsonld
+++ b/packages/catalog/catalog/datasets/aat-materials.jsonld
@@ -32,7 +32,6 @@
       "@id": "http://www.getty.edu/research/"
     }
   ],
-  "url": ["http://vocab.getty.edu/aat/"],
   "mainEntityOfPage": [
     "https://www.getty.edu/research/tools/vocabularies/aat/about.html"
   ],

--- a/packages/catalog/catalog/datasets/aat-processes-and-techniques.jsonld
+++ b/packages/catalog/catalog/datasets/aat-processes-and-techniques.jsonld
@@ -32,7 +32,6 @@
       "@id": "http://www.getty.edu/research/"
     }
   ],
-  "url": ["http://vocab.getty.edu/aat/"],
   "mainEntityOfPage": [
     "https://www.getty.edu/research/tools/vocabularies/aat/about.html"
   ],

--- a/packages/catalog/catalog/datasets/aat-styles-and-periods.jsonld
+++ b/packages/catalog/catalog/datasets/aat-styles-and-periods.jsonld
@@ -35,7 +35,6 @@
       "@id": "http://www.getty.edu/research/"
     }
   ],
-  "url": ["http://vocab.getty.edu/aat/"],
   "mainEntityOfPage": [
     "https://www.getty.edu/research/tools/vocabularies/aat/about.html"
   ],

--- a/packages/catalog/catalog/datasets/cht-materials.jsonld
+++ b/packages/catalog/catalog/datasets/cht-materials.jsonld
@@ -32,7 +32,6 @@
       "@id": "https://www.cultureelerfgoed.nl"
     }
   ],
-  "url": ["https://data.cultureelerfgoed.nl/term/id/cht/"],
   "mainEntityOfPage": [
     "https://kennis.cultureelerfgoed.nl/index.php/Thesauri_bij_de_RCE_-_Cultuurhistorische_Thesaurus"
   ],

--- a/packages/catalog/catalog/datasets/cht-styles-and-periods.jsonld
+++ b/packages/catalog/catalog/datasets/cht-styles-and-periods.jsonld
@@ -35,7 +35,6 @@
       "@id": "https://www.cultureelerfgoed.nl"
     }
   ],
-  "url": ["https://data.cultureelerfgoed.nl/term/id/cht/"],
   "mainEntityOfPage": [
     "https://kennis.cultureelerfgoed.nl/index.php/Thesauri_bij_de_RCE_-_Cultuurhistorische_Thesaurus"
   ],

--- a/packages/catalog/catalog/datasets/geonames-nl-be-de.jsonld
+++ b/packages/catalog/catalog/datasets/geonames-nl-be-de.jsonld
@@ -22,7 +22,6 @@
       "@id": "https://www.geonames.org/team.html"
     }
   ],
-  "url": ["https://sws.geonames.org/"],
   "mainEntityOfPage": ["https://www.geonames.org/about.html"],
   "description": [
     {

--- a/packages/catalog/catalog/datasets/wikidata-entities-persons.jsonld
+++ b/packages/catalog/catalog/datasets/wikidata-entities-persons.jsonld
@@ -22,7 +22,6 @@
       "@id": "https://www.wikidata.org/entity/Q180"
     }
   ],
-  "url": ["http://www.wikidata.org/entity/"],
   "mainEntityOfPage": ["https://www.wikidata.org"],
   "description": [
     {

--- a/packages/catalog/catalog/datasets/wikidata-entities-places.jsonld
+++ b/packages/catalog/catalog/datasets/wikidata-entities-places.jsonld
@@ -22,7 +22,6 @@
       "@id": "https://www.wikidata.org/entity/Q180"
     }
   ],
-  "url": ["http://www.wikidata.org/entity/"],
   "mainEntityOfPage": ["https://www.wikidata.org"],
   "description": [
     {

--- a/packages/catalog/catalog/datasets/wikidata-entities-streets.jsonld
+++ b/packages/catalog/catalog/datasets/wikidata-entities-streets.jsonld
@@ -22,7 +22,6 @@
       "@id": "https://www.wikidata.org/entity/Q180"
     }
   ],
-  "url": ["http://www.wikidata.org/entity/"],
   "mainEntityOfPage": ["https://www.wikidata.org"],
   "description": [
     {

--- a/packages/catalog/shacl/dataset.jsonld
+++ b/packages/catalog/shacl/dataset.jsonld
@@ -57,7 +57,6 @@
           "sh:path": {
             "@id": "schema:url"
           },
-          "sh:minCount": 1,
           "sh:nodeKind": {
             "@id": "sh:IRI"
           }

--- a/packages/catalog/src/getCatalog.ts
+++ b/packages/catalog/src/getCatalog.ts
@@ -110,7 +110,12 @@ const catalogSchema = {
     },
   },
   mainEntityOfPage: schema.mainEntityOfPage,
-  url: schema.url,
+  // Optional: datasets that share a terms-URI prefix with a broader dataset
+  // (e.g. Wikidata subsets) omit it, so lookups resolve to the broader one.
+  url: {
+    '@id': schema.url,
+    '@optional': true,
+  },
 } as const;
 
 const engine = new QueryEngine();
@@ -133,7 +138,7 @@ export async function fromStore(store: RDF.Store): Promise<Catalog> {
           dataset.name,
           dataset.description,
           dataset.genres,
-          [dataset.url],
+          dataset.url ? [dataset.url] : [],
           dataset.mainEntityOfPage,
           dataset.inLanguage,
           [

--- a/packages/catalog/test/catalog.test.ts
+++ b/packages/catalog/test/catalog.test.ts
@@ -76,6 +76,73 @@ describe('Catalog', () => {
     expect(rkd?.iri).toEqual('https://data.rkd.nl/rkdartists');
   });
 
+  it('resolves term IRIs shared by multiple datasets to the broadest one', () => {
+    expect(
+      catalog.getDatasetByTermIri('http://www.wikidata.org/entity/Q230141')
+        ?.iri,
+    ).toEqual('https://www.wikidata.org#entities-all');
+    expect(
+      catalog.getDatasetByTermIri('http://vocab.getty.edu/aat/300010358')?.iri,
+    ).toEqual('http://vocab.getty.edu/aat');
+    expect(
+      catalog.getDatasetByTermIri(
+        'https://data.cultureelerfgoed.nl/term/id/cht/b47bd52f-97e5-402b-a2b6-3a0bb56e4e51',
+      )?.iri,
+    ).toEqual('https://data.cultureelerfgoed.nl/term/id/cht');
+    expect(
+      catalog.getDatasetByTermIri('https://sws.geonames.org/2745912/')?.iri,
+    ).toEqual('https://www.geonames.org');
+  });
+
+  it('declares each terms prefix on a single dataset, except known shared prefixes', () => {
+    // Datasets sharing these prefixes are told apart by each term’s
+    // skos:inScheme in their lookup query results instead; see
+    // https://github.com/netwerk-digitaal-erfgoed/network-of-terms/issues/1863
+    // for modelling them as first-class groups.
+    const sharedPrefixes = [
+      'http://data.beeldengeluid.nl/gtaa', // GTAA
+      'http://data.bibliotheken.nl/id/thes/', // KB: Brinkman, NTA, STCN, corporations
+      'https://data.muziekweb.nl/Link/', // Muziekweb
+      'https://terms.personsincontext.org/ThesaurusHistorischePersoonsgegevens/', // PiCo-T
+    ];
+    const datasetsByPrefix = new Map<string, string[]>();
+    for (const dataset of catalog.datasets) {
+      for (const prefix of dataset.termsPrefixes) {
+        datasetsByPrefix.set(prefix, [
+          ...(datasetsByPrefix.get(prefix) ?? []),
+          dataset.iri,
+        ]);
+      }
+    }
+    for (const [prefix, datasetIris] of datasetsByPrefix) {
+      if (sharedPrefixes.some((shared) => prefix.startsWith(shared))) {
+        continue;
+      }
+      expect(
+        datasetIris,
+        `prefix ${prefix} must be declared by a single dataset so that lookups resolve deterministically; broader/subset datasets must declare it only on the broadest one`,
+      ).toHaveLength(1);
+    }
+  });
+
+  it('covers datasets without a terms prefix through a broader dataset', () => {
+    for (const dataset of catalog.datasets) {
+      if (dataset.termsPrefixes.length > 0) {
+        continue;
+      }
+      const broader = catalog.datasets.find(
+        (candidate) =>
+          candidate.termsPrefixes.length > 0 &&
+          candidate.distributions[0].endpoint ===
+            dataset.distributions[0].endpoint,
+      );
+      expect(
+        broader,
+        `${dataset.iri} declares no terms prefix (schema:url), so a broader dataset on the same endpoint must declare one for lookups to work`,
+      ).toBeDefined();
+    }
+  });
+
   it('retrieves distributions providing feature', () => {
     const reconciliationApis = catalog.getDistributionsProvidingFeature(
       FeatureType.RECONCILIATION,


### PR DESCRIPTION
Looking up a term URI that several catalog datasets claim (e.g. `http://www.wikidata.org/entity/Q230141`) attributed the result to an arbitrary subset dataset – whichever happened to be indexed last – so every Wikidata lookup showed ‘Wikidata: streets in the Netherlands’ as its source.

Fix #1885

## Changes

- **Declare each shared terms-URI prefix only on the broadest dataset.** Removed `schema:url` from nine subset datasets – Wikidata persons/places/streets (owner: all entities), the three AAT subsets (owner: AAT), the two CHT subsets (owner: CHT), and GeoNames NL-BE-DE (owner: GeoNames global) – so `getDatasetByTermIri` resolves those URI spaces to the broadest dataset. Each owner shares its endpoint and lookup query with its subsets, so query behavior is unchanged; only source attribution changes.
- **Make `schema:url` optional** in the catalog loader (ldkit schema) and the SHACL shape.
- **Guard the invariants with catalog tests:** shared-prefix term IRIs resolve to the broadest dataset; every prefix has a single owner (with an allowlist for the GTAA/KB/Muziekweb/PiCo-T families, which are disambiguated via `skos:inScheme` or await #1863); and a dataset without a prefix must share its endpoint with a prefix-owning dataset, so a standalone dataset can’t silently ship without one.
- **Document the convention** in the catalog README.

AAT, CHT, and GeoNames had the same latent bug but were accidentally correct because their broadest file happened to load last; this makes the behavior intentional instead of load-order-dependent.

**Breaking:** lookup responses for these URI spaces now report the broadest source (e.g. `https://www.wikidata.org#entities-all` instead of `https://www.wikidata.org#entities-persons`), and the subset datasets’ `termsPrefixes` are now empty.

Known remaining cases (pre-existing, out of scope): Muziekweb and PiCo-T share prefixes without a broader dataset and without `skos:inScheme` routing in their lookup queries; they need #1863 or `inScheme` bindings.
