### PR TITLE
Attribute Muziekweb terms to the right sub-dataset

### DIFF
--- a/packages/catalog/catalog/queries/lookup/muziekweb.rq
+++ b/packages/catalog/catalog/queries/lookup/muziekweb.rq
@@ -13,6 +13,7 @@ CONSTRUCT {
         skos:scopeNote ?schema_description ;
         skos:broader ?broader_uri ;
         skos:narrower ?narrower_uri ;
+        skos:inScheme ?datasetUri ;
         skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
@@ -23,8 +24,13 @@ WHERE {
     # Music genre: <https://data.muziekweb.nl/Link/T00000000050>
     VALUES ?uri { ?uris }
 
+    # Both Muziekweb datasets share the terms URI prefix, so bind the dataset that the
+    # term’s type belongs to; the Network of Terms uses it to attribute the term correctly.
     ?uri a ?type .
-    VALUES ?type { muziekweb:Genre schema:MusicGroup } .
+    VALUES (?type ?datasetUri) {
+        (muziekweb:Genre <https://data.muziekweb.nl/MuziekwebOrganization/Muziekweb#mw-genresstijlen>)
+        (schema:MusicGroup <https://data.muziekweb.nl/MuziekwebOrganization/Muziekweb#mw-personengroepen>)
+    }
 
     OPTIONAL { ?uri rdfs:label ?rdfs_label }
     OPTIONAL { ?uri skos:prefLabel ?prefLabel }


### PR DESCRIPTION
The two Muziekweb datasets share the terms URI prefix `https://data.muziekweb.nl/Link/`, so `Catalog.getDatasetByTermIri` keeps only one of them and every Muziekweb URI lookup was attributed to whichever dataset happened to be indexed last – a genre could be reported as coming from ‘Muziekweb: personen en groepen’, or the other way around.

`LookupService.lookup` already re-routes each term to its own dataset using the `skos:inScheme` value in the lookup result, but `queries/lookup/muziekweb.rq` constructed no such triple. This binds the dataset IRI alongside the term type – the query already distinguishes `muziekweb:Genre` from `schema:MusicGroup` – and constructs `skos:inScheme` from it, so the existing re-routing does the rest. No code changes.

Verified against the Muziekweb SPARQL endpoint: `Link/T00000000050` (Bossa nova) now carries `#mw-genresstijlen` and `Link/M00000034333` (Red Hot Chili Peppers) `#mw-personengroepen`.

This is option 1 from the issue.

Fix #1901
