### PR TITLE
Attribute PoolParty terms to their own sub-dataset

### DIFF
--- a/packages/catalog/README.md
+++ b/packages/catalog/README.md
@@ -79,6 +79,15 @@ Search and lookup queries are SPARQL `CONSTRUCT` queries that the Network of Ter
 - `?query` – the search string, lowercased and trimmed (the default `OPTIMIZED` query mode).
 - `?virtuosoQuery` – the same string with each token quoted and joined by `AND`, ready for Virtuoso’s `bif:contains`.
 - `?uris` in lookup queries – replaced by `VALUES ?uri { … }` with the URIs being looked up.
+- `?datasetUri` in search queries – bound to the IRI of the dataset being searched.
+
+#### Attributing terms to the right dataset
+
+Several datasets may share a terms URI prefix (`schema:url`), for example when one thesaurus is published as multiple
+sub-datasets. A URI lookup can then only be routed by prefix to one of them, so **lookup queries should construct
+`?uri skos:inScheme ?datasetUri`** with `?datasetUri` bound to the IRI of the dataset that the term belongs to – either
+from the source’s own `skos:inScheme` statements, or from a `VALUES` clause that maps the term’s type to a dataset IRI.
+The Network of Terms uses that triple to attribute the term to its own dataset instead of the one the prefix pointed at.
 
 #### Full-text search
 

--- a/packages/catalog/catalog/queries/lookup/poolparty.rq
+++ b/packages/catalog/catalog/queries/lookup/poolparty.rq
@@ -9,6 +9,7 @@ CONSTRUCT {
         skos:broader ?broader_uri ;
         skos:narrower ?narrower_uri ;
         skos:related ?related_uri ;
+        skos:inScheme ?datasetUri ;
         skos:exactMatch ?exactMatch_uri .
     ?broader_uri skos:prefLabel ?broader_prefLabel .
     ?narrower_uri skos:prefLabel ?narrower_prefLabel .
@@ -34,6 +35,10 @@ WHERE {
         UNION { ?uri skos:hiddenLabel ?hiddenLabel . }
         UNION { ?uri skos:scopeNote ?scopeNote . }
         UNION { ?uri skos:definition ?scopeNote . }
+        # Several datasets can share a terms URI prefix (e.g. the three PiCo-T
+        # sub-thesauri), in which case the Network of Terms uses the concept
+        # scheme to attribute the term to the dataset it really belongs to.
+        UNION { ?uri skos:inScheme ?datasetUri . }
         UNION {
             ?uri skos:broader ?broader_uri .
             ?broader_uri skos:prefLabel ?broader_prefLabel .


### PR DESCRIPTION
The three PiCo-T datasets – rollen (`…/44`), brontypen (`…/523`) and gebeurtenistypen (`…/73`) – share the terms URI prefix `https://terms.personsincontext.org/ThesaurusHistorischePersoonsgegevens/`. `Catalog.getDatasetByTermIri` keeps one dataset per prefix, so a URI lookup of any PiCo-T term was attributed to whichever of the three happened to be indexed last.

`LookupService.lookup` already re-routes a term to its own dataset using the term’s `skos:inScheme`, but the shared `queries/lookup/poolparty.rq` never constructed that triple. The PiCo-T endpoint does publish it, and each concept’s scheme is exactly one of the three dataset IRIs, so no property path over `skos:broader*` is needed.

Fix #1902

## Changes

- **Construct `skos:inScheme` in `queries/lookup/poolparty.rq`**, bound from the source’s own concept scheme, so the existing re-routing resolves each PiCo-T term to its own sub-dataset. Verified through the real `LookupService` against the live endpoint: `…/479` now resolves to `#roles`, `…/526` to `#source-types` and `…/74` to `#events`.
- **Bind it in its own `UNION` branch**, following the pattern the file already documents for independently multi-valued properties, so the scheme does not multiply the other branches’ rows against the `LIMIT 1000`.
- **Document the convention** in the catalog README, together with the `?datasetUri` placeholder, which was not documented before.

Fixing this in the shared query rather than a PiCo-T fork also covers any future PoolParty source that is split into sub-datasets.

## Why the other thirteen datasets are unaffected

This query is shared by fourteen datasets across ten endpoints, so the change was checked against all of them rather than reasoned about:

- **Attribution is unchanged.** Enumerating every distinct concept scheme on all ten endpoints, the only scheme IRIs that match a catalog dataset or distribution IRI are PiCo-T’s three. Everywhere else the schemes are sub-IRIs (e.g. `…/term/id/cht/b532325c-…`, `…/homosaurus/Homosaurus`), so `getDatasetByIri` returns `undefined` and attribution falls back to the queried dataset exactly as today.
- **No result is lost.** Running the old and the new query side by side on all ten endpoints, against real concepts from each, no endpoint drops a single triple; the only difference is the added `skos:inScheme` triple, one per term.
- **Sources without `skos:inScheme` still work.** The scheme sits in its own `UNION` branch, so where it is absent the branch simply contributes no solutions and the term is returned unchanged.
- **Concepts in more than one scheme are harmless.** Westerbork has a few. `TermsTransformer.inScheme` is single-valued, so one wins arbitrarily – but since no Westerbork scheme matches a catalog IRI, both resolve to nothing and attribution is unaffected.

## Known limitation

35 of PiCo-T’s 101 concepts are `owl:deprecated` tombstones carrying only an `rdfs:label` – no `skos:prefLabel`, no `skos:broader`, no scheme. They match no branch of the lookup query and return nothing, before and after this change, so a lookup of one still reports “not found” against an arbitrary one of the three datasets. Attributing those would need #1863.

This complements #1903, which fixes the same class of bug for Muziekweb by binding the dataset IRI from the term’s type.
