### PR TITLE
fix(catalog): look up Rights terms by their Creative Commons and RightsStatements.org URIs

### DIFF
--- a/packages/catalog/README.md
+++ b/packages/catalog/README.md
@@ -33,7 +33,9 @@ additions specific to the Network of Terms:
   resources. This prefix is needed when clients look up terms by their URI in the Network of Terms: the Network then has
   to know which source to consult to retrieve the term. If the dataset is a subset of a broader dataset in the same URI
   space (e.g. ‘Wikidata: persons’ is a subset of ‘Wikidata: all entities’), omit `schema:url`: only the
-  broadest dataset declares the prefix, so that lookups resolve to it rather than to an arbitrary subset;
+  broadest dataset declares the prefix, so that lookups resolve to it rather than to an arbitrary subset. A dataset
+  that holds terms in more than one URI space declares `schema:url` once per prefix, for example the Rights thesaurus,
+  which reuses the canonical Creative Commons and RightsStatements.org URIs alongside its own;
 - `schema:inLanguage` is a required property;
 - `schema:genre` is a required property, with values restricted to the list of [Termennetwerk onderwerpen](https://data.cultureelerfgoed.nl/termennetwerk/onderwerpen.html);
 - `schema:mainEntityOfPage` is a required property;

--- a/packages/catalog/catalog/datasets/rights.jsonld
+++ b/packages/catalog/catalog/datasets/rights.jsonld
@@ -33,7 +33,10 @@
     }
   ],
   "url": [
-    "https://data.cultureelerfgoed.nl/rights/"
+    "https://data.cultureelerfgoed.nl/rights/",
+    "https://creativecommons.org/",
+    "http://rightsstatements.org/",
+    "https://rightsstatements.org/"
   ],
   "mainEntityOfPage": [
     "https://data.cultureelerfgoed.nl/rights.html"

--- a/packages/catalog/src/getCatalog.ts
+++ b/packages/catalog/src/getCatalog.ts
@@ -110,10 +110,14 @@ const catalogSchema = {
     },
   },
   mainEntityOfPage: schema.mainEntityOfPage,
-  // Optional: datasets that share a terms-URI prefix with a broader dataset
-  // (e.g. Wikidata subsets) omit it, so lookups resolve to the broader one.
+  // Multiple: a dataset may hold terms in more than one URI space, e.g. the
+  // Rights thesaurus, which reuses the canonical Creative Commons and
+  // RightsStatements.org URIs. Optional: datasets that share a terms-URI prefix
+  // with a broader dataset (e.g. Wikidata subsets) omit it, so lookups resolve
+  // to the broader one.
   url: {
     '@id': schema.url,
+    '@array': true,
     '@optional': true,
   },
 } as const;
@@ -138,7 +142,7 @@ export async function fromStore(store: RDF.Store): Promise<Catalog> {
           dataset.name,
           dataset.description,
           dataset.genres,
-          dataset.url ? [dataset.url] : [],
+          dataset.url,
           dataset.mainEntityOfPage,
           dataset.inLanguage,
           [

--- a/packages/catalog/test/catalog.test.ts
+++ b/packages/catalog/test/catalog.test.ts
@@ -94,6 +94,19 @@ describe('Catalog', () => {
     ).toEqual('https://www.geonames.org');
   });
 
+  it('resolves term IRIs of datasets that hold terms in multiple URI spaces', () => {
+    for (const termIri of [
+      'https://data.cultureelerfgoed.nl/rights/cc-licenties',
+      'https://creativecommons.org/licenses/by-nc/4.0/',
+      'http://rightsstatements.org/vocab/InC/1.0/',
+      'https://rightsstatements.org/vocab/InC-RUU/1.0/',
+    ]) {
+      expect(catalog.getDatasetByTermIri(termIri)?.iri, termIri).toEqual(
+        'https://data.cultureelerfgoed.nl/rights',
+      );
+    }
+  });
+
   it('declares each terms prefix on a single dataset, except known shared prefixes', () => {
     // Datasets sharing these prefixes are told apart by each term’s
     // skos:inScheme in their lookup query results instead; see

--- a/packages/catalog/test/catalog.test.ts
+++ b/packages/catalog/test/catalog.test.ts
@@ -12,9 +12,11 @@ import { fileURLToPath } from 'url';
 let catalog: Catalog;
 
 describe('Catalog', () => {
+  // Parsing and querying the catalog is CPU-bound: ~2s locally, but it
+  // repeatedly exceeded 20s on CI runners that also run other tasks.
   beforeAll(async () => {
     catalog = await getCatalog();
-  }, 20_000);
+  }, 60_000);
 
   it('lists datasets in alphabetical order', () => {
     expect(catalog.datasets.length).toBeGreaterThan(3);


### PR DESCRIPTION
Looking up a term of the Rights Status and Usage Rights thesaurus by its URI failed with `No source found that can provide term with URI …`, so following a narrower term from search results led nowhere.

The thesaurus deliberately reuses Creative Commons and RightsStatements.org URIs as its concept URIs, but the catalog could only route lookups through the single `https://data.cultureelerfgoed.nl/rights/` prefix, which no CC or RS URI starts with.

- Accept multiple `schema:url` terms prefixes per dataset in the catalog loader, for sources whose terms live in more than one URI space. `Dataset.termsPrefixes` was already an array; only the loader collapsed it to one value.
- Declare the `creativecommons.org` and `rightsstatements.org` prefixes on the Rights thesaurus alongside its own.
- Document the convention in the catalog README and pin the routing in a catalog test.
- Raise the catalog-loading hook timeout in `catalog.test.ts` from 20s to 60s. Loading the catalog is CPU-bound (~2s locally) and repeatedly exceeded 20s on CI runners running other tasks in parallel – it fails on master too, e.g. run 30254216562. Unrelated to this change: with and without the `@array` schema change, loading takes 1.6s locally either way.

Both the `http://` and `https://` form of `rightsstatements.org` are declared: the thesaurus publishes eight statements under the canonical `http://rightsstatements.org/vocab/`, but InC-RUU only under `https://rightsstatements.org/vocab/InC-RUU/1.0/` (see #1907). Declaring both keeps lookups working whichever form a client holds, before and after the source data is corrected.

For Creative Commons the source uses `https://` exclusively, so that is the only prefix declared. CC is ambiguous about which form is canonical: the deed page states the canonical URL is `https://`, while its RDF still identifies licenses by `http://` (`<cc:License rdf:about="http://creativecommons.org/licenses/by-nc/4.0/">`) – deliberately so, as CC keeps `http://` inside RDF while migrating human-facing links to https (creativecommons/cc-legal-tools-app#65). Clients holding the `http://` form – common in older heritage metadata – therefore still get no result; whether the thesaurus should use the RDF form is a separate question.

Verified against the live endpoint: `https://creativecommons.org/licenses/by-nc/4.0/` now resolves to the Rights source and returns ‘CC BY-NC’, and `http://rightsstatements.org/vocab/InC/1.0/` returns ‘In Copyright’ / ‘Auteursrechtelijk beschermd’.

Fix #1905
