### PR TITLE
feat(graphql)!: return structured place data for GeoNames

### DIFF
--- a/packages/catalog/catalog/queries/lookup/geonames.rq
+++ b/packages/catalog/catalog/queries/lookup/geonames.rq
@@ -1,20 +1,27 @@
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX gn: <https://www.geonames.org/ontology#>
+PREFIX schema: <https://schema.org/>
+PREFIX wgs84: <http://www.w3.org/2003/01/geo/wgs84_pos#>
 
 CONSTRUCT {
-    ?uri a skos:Concept ;
+    ?uri a skos:Concept , schema:Place ;
         skos:prefLabel ?prefLabel_ext ;
         skos:altLabel ?altLabel ;
         skos:scopeNote ?scopeNote_en ;
-        skos:broader ?broader .
+        skos:broader ?broader ;
+        schema:latitude ?latitude ;
+        schema:longitude ?longitude .
     ?broader skos:prefLabel ?broader_prefLabel .
 }
 WHERE {
-    # https://sws.geonames.org/2752375 (Koudekerke)
+    # Term URIs carry a trailing slash, e.g. https://sws.geonames.org/2752375/ (Koudekerke).
     VALUES ?uri { ?uris }
 
+    # Every feature has exactly one point, including countries and continents.
     ?uri a gn:Feature ;
-        gn:name ?prefLabel .
+        gn:name ?prefLabel ;
+        wgs84:lat ?latitude ;
+        wgs84:long ?longitude .
 
     # Supranational features (continents and the planet) have no country code.
     OPTIONAL { ?uri gn:countryCode ?countryCode . }

--- a/packages/catalog/catalog/queries/search/geonames.rq
+++ b/packages/catalog/catalog/queries/search/geonames.rq
@@ -1,14 +1,18 @@
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX gn: <https://www.geonames.org/ontology#>
+PREFIX schema: <https://schema.org/>
 PREFIX text: <http://jena.apache.org/text#>
 PREFIX vrank: <http://purl.org/voc/vrank#>
+PREFIX wgs84: <http://www.w3.org/2003/01/geo/wgs84_pos#>
 
 CONSTRUCT {
-    ?uri a skos:Concept ;
+    ?uri a skos:Concept , schema:Place ;
         skos:prefLabel ?prefLabel_ext ;
         skos:altLabel ?altLabel ;
         skos:scopeNote ?scopeNote_en , ?scopeNote_nl ;
         skos:broader ?broader ;
+        schema:latitude ?latitude ;
+        schema:longitude ?longitude ;
         vrank:simpleRank ?score .
     ?broader skos:prefLabel ?broader_prefLabel .
 }
@@ -39,7 +43,10 @@ WHERE {
         #LIMIT#
     }
 
-    ?uri gn:name ?prefLabel .
+    # Every feature has exactly one point, including countries and continents.
+    ?uri gn:name ?prefLabel ;
+        wgs84:lat ?latitude ;
+        wgs84:long ?longitude .
 
     BIND(IF(BOUND(?countryCode), CONCAT(?prefLabel," (",UCASE(?countryCode),")"), ?prefLabel) as ?prefLabel_ext)
 

--- a/packages/graphql/src/resolvers.ts
+++ b/packages/graphql/src/resolvers.ts
@@ -176,9 +176,11 @@ class TranslatedTerms {
   constructor(readonly terms: object[]) {}
 }
 
+type TranslatedTermType = 'Concept' | 'Person' | 'Place';
+
 function mapToTranslatedTerm(term: Term, languages: string[]) {
   return {
-    type: 'TranslatedTerm',
+    type: translatedTermType(term),
     uri: term.id!.value,
     prefLabel: filterLiteralsByLanguage(term.prefLabels, languages),
     altLabel: filterLiteralsByLanguage(term.altLabels, languages),
@@ -202,8 +204,45 @@ function mapToTranslatedTerm(term: Term, languages: string[]) {
       uri: exactMatch.id.value,
       prefLabel: filterLiteralsByLanguage(exactMatch.prefLabels, languages),
     })),
+    latitude: floatValue(term.latitude),
+    longitude: floatValue(term.longitude),
   };
 }
+
+/**
+ * The `TranslatedTerm` implementation that the term’s asserted types map to.
+ *
+ * Terms that are not typed by their source, or typed as something we have no GraphQL type for, are
+ * `Concept`s: SKOS remains the frame, so `skos:Concept` is the default rather than an error.
+ */
+function translatedTermType(term: Term): TranslatedTermType {
+  for (const type of term.types) {
+    const translatedTermType = classToTranslatedTermType.get(type.value);
+    if (translatedTermType !== undefined) {
+      return translatedTermType;
+    }
+  }
+
+  return 'Concept';
+}
+
+// Both Schema.org namespaces, because source queries use either one.
+const classToTranslatedTermType = new Map<string, TranslatedTermType>([
+  ['https://schema.org/Person', 'Person'],
+  ['http://schema.org/Person', 'Person'],
+  ['https://schema.org/Place', 'Place'],
+  ['http://schema.org/Place', 'Place'],
+]);
+
+/**
+ * Sources are not validated, so a coordinate may be absent, empty or not a number at all. Anything
+ * we cannot read as a finite number becomes null: an unknown coordinate is not a field error, and
+ * `Number('')` would silently place the term at 0°, 0°.
+ */
+const floatValue = (literal: RDF.Literal | undefined) => {
+  const value = Number(literal?.value);
+  return Number.isFinite(value) && literal?.value.trim() !== '' ? value : null;
+};
 
 function mapToTerm(term: Term, languages: string[]) {
   return {
@@ -298,8 +337,11 @@ export const resolvers = {
       return 'Source';
     },
   },
+  TranslatedTerm: {
+    resolveType: (term: { type: TranslatedTermType }) => term.type,
+  },
   LookupResult: {
-    resolveType(result: LookupResult | { type: 'TranslatedTerm' }) {
+    resolveType(result: LookupResult | { type: TranslatedTermType }) {
       if (result instanceof NotFoundError) {
         return 'NotFoundError';
       }
@@ -312,8 +354,8 @@ export const resolvers = {
         return 'ServerError';
       }
 
-      if (result.type === 'TranslatedTerm') {
-        return 'TranslatedTerm';
+      if ('type' in result) {
+        return result.type;
       }
 
       return 'Term';

--- a/packages/graphql/src/schema.ts
+++ b/packages/graphql/src/schema.ts
@@ -158,18 +158,38 @@ export const schema = (languages: string[]) => `
     terms: [TranslatedTerm]
   }
   
-  type TranslatedTerm {
-    uri: ID!
-    prefLabel: [LanguageString]!
-    altLabel: [LanguageString]!
-    hiddenLabel: [LanguageString]!
-    definition: [LanguageString]!
-    scopeNote: [LanguageString]!
-    seeAlso: [String]!
-    broader: [TranslatedRelatedTerm]
-    narrower: [TranslatedRelatedTerm]
-    related: [TranslatedRelatedTerm]
-    exactMatch: [TranslatedRelatedTerm]
+  """
+  A description of a concept or entity, expressed in the SKOS vocabulary, with labels in the requested languages.
+  """
+  interface TranslatedTerm {
+${translatedTermFields}
+  }
+
+  """
+  A term whose source identifies it as nothing more specific. Every term is a \`skos:Concept\`; this is the type for terms that are only that.
+  """
+  type Concept implements TranslatedTerm {
+${translatedTermFields}
+  }
+
+  """
+  A term that describes a person.
+  """
+  type Person implements TranslatedTerm {
+${translatedTermFields}
+  }
+
+  """
+  A term that describes a place.
+  """
+  type Place implements TranslatedTerm {
+${translatedTermFields}
+
+    "Latitude of the place, in the WGS 84 coordinate reference system."
+    latitude: Float
+
+    "Longitude of the place, in the WGS 84 coordinate reference system."
+    longitude: Float
   }
   
   type TranslatedRelatedTerm {
@@ -198,7 +218,7 @@ export const schema = (languages: string[]) => `
 
   union SourceResult = Source | SourceNotFoundError
 
-  union LookupResult = Term | TranslatedTerm | NotFoundError | TimeoutError | ServerError
+  union LookupResult = Term | Concept | Person | Place | NotFoundError | TimeoutError | ServerError
 
   """
   The term source failed to respond within the timeout period.
@@ -232,3 +252,19 @@ export const schema = (languages: string[]) => `
     message: String!
   }
 `;
+
+/**
+ * The fields shared by all `TranslatedTerm` implementations. GraphQL has no inheritance, so each
+ * implementing type must redeclare every interface field.
+ */
+const translatedTermFields = `    uri: ID!
+    prefLabel: [LanguageString]!
+    altLabel: [LanguageString]!
+    hiddenLabel: [LanguageString]!
+    definition: [LanguageString]!
+    scopeNote: [LanguageString]!
+    seeAlso: [String]!
+    broader: [TranslatedRelatedTerm]
+    narrower: [TranslatedRelatedTerm]
+    related: [TranslatedRelatedTerm]
+    exactMatch: [TranslatedRelatedTerm]`;

--- a/packages/graphql/test/server.test.ts
+++ b/packages/graphql/test/server.test.ts
@@ -146,7 +146,9 @@ describe('Server', () => {
       'Rembrandt',
       'Nachtwacht',
       'Kunstige dingen',
+      'Maastricht',
       'Marion Michelle Koblitz',
+      'Nergenshuizen',
       '',
       '',
     ]); // Results with score must come first.
@@ -184,11 +186,22 @@ describe('Server', () => {
     );
     expect(body.data.terms).toHaveLength(1);
     expect(body.data.terms[0].result.__typename).toEqual('TranslatedTerms');
-    expect(body.data.terms[0].result.translatedTerms).toHaveLength(6); // Terms found.
+    expect(body.data.terms[0].result.translatedTerms).toHaveLength(8); // Terms found.
     expect(body.data.terms[0].result.translatedTerms[1].prefLabel).toEqual([
       { language: 'nl', value: 'Nachtwacht' },
       { language: 'en', value: 'The Night Watch' },
     ]);
+    expect(body.data.terms[0].result.translatedTerms[1].__typename).toEqual(
+      'Concept',
+    );
+
+    const place = body.data.terms[0].result.translatedTerms.find(
+      (term: { uri: string }) =>
+        term.uri === 'https://example.com/resources/place',
+    );
+    expect(place.__typename).toEqual('Place');
+    expect(place.latitude).toEqual(50.84833);
+    expect(place.longitude).toEqual(5.68889);
   });
 
   it('responds to successful GraphQL terms query with backwards compatible distribution URI', async () => {
@@ -204,7 +217,7 @@ describe('Server', () => {
     expect(body.data.terms[0].source.uri).toEqual(
       'https://data.rkd.nl/rkdartists',
     );
-    expect(body.data.terms[0].result.terms).toHaveLength(6); // Terms found.
+    expect(body.data.terms[0].result.terms).toHaveLength(8); // Terms found.
   });
 
   it('respects GraphQL terms query limit', async () => {
@@ -304,7 +317,7 @@ describe('Server', () => {
       }),
     );
     const term = body.data.lookup[0];
-    expect(term.result.__typename).toEqual('TranslatedTerm');
+    expect(term.result.__typename).toEqual('Concept');
     expect(term.result.prefLabel).toEqual([
       {
         language: 'en',
@@ -321,10 +334,41 @@ describe('Server', () => {
       }),
     );
     const term = body.data.lookup[0];
-    expect(term.result.__typename).toEqual('TranslatedTerm');
+    expect(term.result.__typename).toEqual('Person');
     expect(term.result.prefLabel).toEqual([
       { language: 'nl', value: 'Marion Michelle Koblitz' },
     ]);
+  });
+
+  it('returns terms typed as schema:Place as Places, with their coordinates', async () => {
+    const body = await query(
+      lookupQuery({
+        uris: ['https://example.com/resources/place'],
+        languages: ['nl'],
+      }),
+    );
+    const term = body.data.lookup[0];
+    expect(term.result.__typename).toEqual('Place');
+    expect(term.result.prefLabel).toEqual([
+      { language: 'nl', value: 'Maastricht' },
+    ]);
+    expect(term.result.latitude).toEqual(50.84833);
+    expect(term.result.longitude).toEqual(5.68889);
+  });
+
+  it('returns null coordinates for places whose source publishes unusable ones', async () => {
+    const body = await query(
+      lookupQuery({
+        uris: ['https://example.com/resources/place-without-coordinates'],
+        languages: ['nl'],
+      }),
+    );
+    const term = body.data.lookup[0];
+    expect(term.result.__typename).toEqual('Place');
+    // An empty literal must not read as 0°, and a non-numeric one must not raise a field error.
+    expect(body.errors).toBeUndefined();
+    expect(term.result.latitude).toBeNull();
+    expect(term.result.longitude).toBeNull();
   });
 
   it('falls back to mul labels in non-multilingual lookup', async () => {
@@ -462,6 +506,7 @@ function termsQuery({
           }
           ... on TranslatedTerms {
             translatedTerms:terms {
+              __typename
               uri
               prefLabel { language value }
               altLabel { language value }
@@ -480,6 +525,10 @@ function termsQuery({
               exactMatch {
                 uri
                 prefLabel { language value }
+              }
+              ... on Place {
+                latitude
+                longitude
               }
             }
           }
@@ -554,6 +603,10 @@ function lookupQuery({
               uri
               prefLabel { language value }
             }
+          }
+          ... on Place {
+            latitude
+            longitude
           }
           `
           }

--- a/packages/query/src/terms.ts
+++ b/packages/query/src/terms.ts
@@ -3,7 +3,7 @@ import type RDF from '@rdfjs/types';
 export class Term {
   constructor(
     readonly id: RDF.Term,
-    readonly type: RDF.Term | undefined,
+    readonly types: RDF.Term[],
     readonly prefLabels: RDF.Literal[],
     readonly altLabels: RDF.Literal[],
     readonly hiddenLabels: RDF.Literal[],
@@ -15,6 +15,8 @@ export class Term {
     readonly exactMatches: RelatedTerm[],
     readonly datasetIri: RDF.Term | undefined,
     readonly score: RDF.Literal | undefined,
+    readonly latitude: RDF.Literal | undefined,
+    readonly longitude: RDF.Literal | undefined,
   ) {}
 }
 
@@ -27,7 +29,7 @@ export class RelatedTerm {
 
 class SparqlResultTerm {
   constructor(readonly id: RDF.Term) {}
-  type: RDF.Term | undefined = undefined;
+  types: RDF.Term[] = [];
   prefLabels: RDF.Literal[] = [];
   altLabels: RDF.Literal[] = [];
   hiddenLabels: RDF.Literal[] = [];
@@ -39,13 +41,15 @@ class SparqlResultTerm {
   exactMatches: RDF.Term[] = [];
   inScheme: RDF.Term | undefined = undefined;
   score: RDF.Literal | undefined = undefined;
+  latitude: RDF.Literal | undefined = undefined;
+  longitude: RDF.Literal | undefined = undefined;
 }
 
 export class TermsTransformer {
   private termsIris: Set<string> = new Set();
   private termsMap: Map<string, SparqlResultTerm> = new Map();
   private readonly predicateToPropertyMap = new Map<string, string>([
-    ['http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'type'],
+    ['http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'types'],
     ['http://www.w3.org/2000/01/rdf-schema#seeAlso', 'seeAlso'],
     ['http://www.w3.org/2004/02/skos/core#prefLabel', 'prefLabels'],
     ['http://www.w3.org/2008/05/skos#prefLabel', 'prefLabels'],
@@ -65,6 +69,11 @@ export class TermsTransformer {
     ['http://www.w3.org/2008/05/skos#exactMatch', 'exactMatches'],
     ['http://www.w3.org/2004/02/skos/core#inScheme', 'inScheme'],
     ['http://purl.org/voc/vrank#simpleRank', 'score'],
+    // Both Schema.org namespaces, because source queries use either one.
+    ['https://schema.org/latitude', 'latitude'],
+    ['http://schema.org/latitude', 'latitude'],
+    ['https://schema.org/longitude', 'longitude'],
+    ['http://schema.org/longitude', 'longitude'],
   ]);
 
   fromQuad(quad: RDF.Quad): void {
@@ -76,7 +85,7 @@ export class TermsTransformer {
 
     // skos:Concepts are the top-level search results, which we track in termsIris.
     if (
-      propertyName === 'type' &&
+      propertyName === 'types' &&
       (quad.object.value === 'http://www.w3.org/2004/02/skos/core#Concept' ||
         quad.object.value === 'http://www.w3.org/2008/05/skos#Concept')
     ) {
@@ -102,7 +111,7 @@ export class TermsTransformer {
 
       return new Term(
         term.id,
-        term.type,
+        term.types,
         term.prefLabels,
         term.altLabels,
         term.hiddenLabels,
@@ -116,6 +125,8 @@ export class TermsTransformer {
         this.mapRelatedTerms(term.exactMatches).sort(alphabeticallyByPrefLabel),
         term.inScheme,
         term.score,
+        term.latitude,
+        term.longitude,
       );
     });
   }

--- a/packages/query/test/fixtures/terms.ttl
+++ b/packages/query/test/fixtures/terms.ttl
@@ -1,6 +1,8 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
 @prefix vrank: <http://purl.org/voc/vrank#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://example.com/resources/artwork>
     a skos:Concept ;
@@ -46,6 +48,19 @@
     skos:prefLabel "Exact match"@en .
 
 <https://example.com/resources/photographer>
-    a skos:Concept ;
+    a skos:Concept, schema:Person ;
     # Wikidata-style ‘default for all languages’ label; see issue #1884.
     skos:prefLabel "Marion Michelle Koblitz"@mul .
+
+<https://example.com/resources/place>
+    a skos:Concept, schema:Place ;
+    skos:prefLabel "Maastricht"@nl ;
+    schema:latitude "50.84833"^^xsd:float ;
+    schema:longitude "5.68889"^^xsd:float .
+
+# A place whose source publishes unusable coordinates; see the `floatValue` guard in resolvers.ts.
+<https://example.com/resources/place-without-coordinates>
+    a skos:Concept, schema:Place ;
+    skos:prefLabel "Nergenshuizen"@nl ;
+    schema:latitude "" ;
+    schema:longitude "onbekend" .


### PR DESCRIPTION
Returns places as structured data instead of only as prose in `skos:scopeNote`, starting with GeoNames. Implements the decisions in https://github.com/netwerk-digitaal-erfgoed/network-of-terms/issues/1514#issuecomment-5342917275.

## GraphQL

`TranslatedTerm` becomes an **interface** of the same name, implemented by `Concept`, `Person` and `Place`. Existing `... on TranslatedTerm` fragments keep matching, so queries do not need to change; only `union LookupResult` changes, to list the concrete members. `__typename` now reports the concrete type rather than `TranslatedTerm`.

`Place` adds `latitude: Float` and `longitude: Float`, flat rather than nested under `schema:geo`/`GeoCoordinates` as SCHEMA-AP-NDE does: the Network of Terms publishes no RDF, so nothing reads the graph and the profile’s shape is not at stake. Flat keeps the CONSTRUCT output and the GraphQL shape identical, so `TermsTransformer` stays a flat predicate→property map.

Both coordinate fields are nullable, and unusable values become null rather than a field error: sources are not validated, an empty literal would otherwise read as 0°, 0°, and a non-numeric one would fail `GraphQLFloat` serialisation.

`Float!` was considered and rejected. A non-null violation propagates to the nearest nullable parent, so a single unusable coordinate returns `"lookup": [null]` and the term disappears from the result entirely, name and all. Nullable is also the direction that keeps our options open: for output fields `Float` → `Float!` is a non-breaking tightening, while `Float!` → `Float` would break clients. That places have coordinates is enforced where it is actually true — in the GeoNames queries — rather than in a type shared with sources that cannot promise it.

`Concept` is the residual type – GraphQL requires a concrete type for terms that are neither person nor place. It is not invented: every source CONSTRUCT asserts `a skos:Concept`. Use `... on TranslatedTerm` for *any* term; places and persons are `skos:Concept`s too, but they do not match `... on Concept`.

Monolingual `Term` is frozen and gains no structure, so coordinates are reachable only when the client passes `languages`. That is the decision recorded in the issue, not an oversight.

## GeoNames

`queries/{search,lookup}/geonames.rq` now construct `a schema:Place` plus `schema:latitude`/`schema:longitude` from the `wgs84_pos#lat`/`#long` already in the store. Both queries were run against `https://geonames.netwerkdigitaalerfgoed.nl/sparql` to confirm the output. The lookup query’s example-URI comment was corrected – term URIs in the store carry a trailing slash.

The coordinates are matched as required triple patterns, not `OPTIONAL`s: all 13,361,899 features in the store have exactly one `wgs84:lat` and one `wgs84:long`, the counts matching exactly. GeoNames models every feature as a point, so even countries and continents carry one (Netherlands `52.25, 5.75`, Europe `48.69, 9.14`) rather than an extent.

Typing is asserted by the source query, never inferred from the presence of coordinates or from the source’s catalog genre (six `Locaties` sources are multi-genre).

**`Person` is declared but not yet reachable in production.** No source CONSTRUCT emits `schema:Person` – the person sources only *match* it in their `WHERE` clause – so every non-GeoNames term currently resolves to `Concept`. The type and its mapping are in place per the agreed design, and land for real with the RKD work; the test covers the mapping against a fixture, not an end-to-end source.

## Backwards compatibility

Additive only. `scopeNote` is unchanged, including the RKD concatenation, so consumers that read it today keep working. Sources that gain structured data will emit both.

`Term.type` in `@netwerk-digitaal-erfgoed/network-of-terms-query` becomes `Term.types`, an array – `fromQuad` previously overwrote it on each `rdf:type` quad – and the `Term` constructor takes two extra trailing arguments. `termsIris` is still keyed off `skos:Concept`, so nothing drops out of results. This is a breaking change to that package’s public API, carried by its own `refactor(query)!` commit; the GraphQL API is unaffected apart from the `__typename` values.

## Versioning

Rebased onto the nx project rename (#1932), which is what lets these commit scopes reach the versioner. Split by package so each bump is derived from a commit scoped to the project it changes. `npx nx release version --dry-run`:

| project | bump | version |
| --- | --- | --- |
| `query` | major | 6.3.14 → 7.0.0 |
| `catalog` | minor | 10.19.30 → 10.20.0 |

Before #1932 both resolved to patch regardless of commit type.

## Coverage thresholds

`vitest.config.ts` is deliberately left at its committed values. A full run produces coverage numbers that vary by roughly half a point between runs, so committing the `autoUpdate` output would pin the thresholds inside that band and make the suite fail intermittently. Raising them from the current stale 73% is worth doing, but as its own change, together with a look at why the numbers move.

## Follow-ups

Wikidata next; other sources after probing their endpoints for coordinates. Reconciliation API, RDF serialisation and result validation stay out of scope, per the issue.

Documentation is updated in a companion PR on the docs repository.

Refs #1514 – first of several PRs, so this one does not close the issue.
