### PR TITLE
build: rename nx projects to match conventional-commit scopes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ npx nx affected -t <target>               # Prefer this for efficiency: changed 
 # Targets: build, test, lint, typecheck, serve
 ```
 
-Project names use the full npm package name: `network-of-terms-catalog`, `network-of-terms-query`, `network-of-terms-graphql`, `network-of-terms-reconciliation`, `network-of-terms-cli`.
+Project names are short and match the conventional-commit scopes: `catalog`, `query`, `graphql`, `reconciliation`, `status`, `cli` (set via `nx.name` in each package’s `package.json`; the npm package name keeps the `@netwerk-digitaal-erfgoed/network-of-terms-` prefix). Scoping a commit to a project name is what lets `nx release` apply that commit’s type – `feat`, `fix`, `!` – to the project’s version bump; a scope that matches no project falls through to a patch.
 
 ## Architecture
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -17,11 +17,11 @@ And execute the commands that you find in each package’s readme (for example
 
     # In the container:
     /app # npm install
-    /app # npx nx serve network-of-terms-graphql
+    /app # npx nx serve graphql
 
     # or:
 
-    /app # npx nx serve network-of-terms-reconciliation
+    /app # npx nx serve reconciliation
 
 You can also use this method if you want to run the application on an
 [Apple silicon](https://support.apple.com/en-gb/HT211814) computer without emulation, as our ready-made Docker images

--- a/nx.json
+++ b/nx.json
@@ -74,7 +74,7 @@
         "projectsRelationship": "independent",
         "projects": ["tag:release:npm"],
         "releaseTag": {
-          "pattern": "{projectName}@{version}"
+          "pattern": "@netwerk-digitaal-erfgoed/network-of-terms-{projectName}@{version}"
         },
         "version": {
           "conventionalCommits": true
@@ -83,7 +83,7 @@
       "apps": {
         "projects": ["tag:release:docker"],
         "releaseTag": {
-          "pattern": "{projectName}@{version}"
+          "pattern": "@netwerk-digitaal-erfgoed/network-of-terms-{projectName}@{version}"
         },
         "docker": {
           "skipVersionActions": true,

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -53,6 +53,7 @@
     "rdf-validate-shacl": "0.6.5"
   },
   "nx": {
+    "name": "catalog",
     "tags": [
       "release:npm"
     ]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,6 +20,9 @@
   "oclif": {
     "commands": "./build"
   },
+  "nx": {
+    "name": "cli"
+  },
   "dependencies": {
     "@oclif/core": "4.11.0",
     "cli-ux": "6.0.9"

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -37,7 +37,7 @@ application locally using Node (or in a [Docker container](../../docs/docker.md)
     git clone https://github.com/netwerk-digitaal-erfgoed/network-of-terms.git
     cd network-of-terms
     npm install
-    npx nx serve network-of-terms-graphql
+    npx nx serve graphql
 
 and open http://localhost:3123 in your browser for the GraphQL Playground. See below for some example queries.
 
@@ -51,7 +51,7 @@ To run your own instance of the Network of Terms GraphQL API with a custom [cata
 1. create your custom catalog that matches the data structure of the [default catalog](../../packages/catalog)
 2. provide the path to your custom catalog in the `CATALOG_PATH` environment variable when starting the server:
 
-       CATALOG_PATH=my-custom-catalog/ npx nx serve network-of-terms-graphql
+       CATALOG_PATH=my-custom-catalog/ npx nx serve graphql
 
 ### Environment variables
 

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -33,6 +33,7 @@
     "node": ">=16.15.0"
   },
   "nx": {
+    "name": "graphql",
     "tags": ["release:docker"],
     "release": {
       "docker": {
@@ -86,15 +87,15 @@
           "build"
         ],
         "options": {
-          "buildTarget": "@netwerk-digitaal-erfgoed/network-of-terms-graphql:build",
+          "buildTarget": "graphql:build",
           "runBuildTargetDependencies": false
         },
         "configurations": {
           "development": {
-            "buildTarget": "@netwerk-digitaal-erfgoed/network-of-terms-graphql:build:development"
+            "buildTarget": "graphql:build:development"
           },
           "production": {
-            "buildTarget": "@netwerk-digitaal-erfgoed/network-of-terms-graphql:build:production"
+            "buildTarget": "graphql:build:production"
           }
         }
       },
@@ -102,7 +103,7 @@
         "continuous": true,
         "executor": "nx:run-commands",
         "options": {
-          "command": "npx nodemon --watch packages/catalog/catalog --exec 'npx nx serve-dev network-of-terms-graphql'"
+          "command": "npx nodemon --watch packages/catalog/catalog --exec 'npx nx serve-dev graphql'"
         }
       },
       "copy-workspace-modules": {},

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -55,6 +55,7 @@
     "asynciterator": "3.10.0"
   },
   "nx": {
+    "name": "query",
     "tags": [
       "release:npm"
     ]

--- a/packages/reconciliation/README.md
+++ b/packages/reconciliation/README.md
@@ -28,7 +28,7 @@ If you want to make changes to the application, run it locally using Node (or in
     git clone https://github.com/netwerk-digitaal-erfgoed/network-of-terms.git
     cd network-of-terms
     npm install
-    npx nx serve network-of-terms-reconciliation
+    npx nx serve reconciliation
 
 In both cases, Reconciliation endpoints will be available at `http://localhost:3123/reconcile/{distribution URI}`, for
 example http://localhost:3123/reconcile/https://data.rkd.nl/rkdartists.

--- a/packages/reconciliation/package.json
+++ b/packages/reconciliation/package.json
@@ -34,6 +34,7 @@
     "accepts": "1.3.8"
   },
   "nx": {
+    "name": "reconciliation",
     "tags": ["release:docker"],
     "release": {
       "docker": {
@@ -94,15 +95,15 @@
           "build"
         ],
         "options": {
-          "buildTarget": "@netwerk-digitaal-erfgoed/network-of-terms-reconciliation:build",
+          "buildTarget": "reconciliation:build",
           "runBuildTargetDependencies": false
         },
         "configurations": {
           "development": {
-            "buildTarget": "@netwerk-digitaal-erfgoed/network-of-terms-reconciliation:build:development"
+            "buildTarget": "reconciliation:build:development"
           },
           "production": {
-            "buildTarget": "@netwerk-digitaal-erfgoed/network-of-terms-reconciliation:build:production"
+            "buildTarget": "reconciliation:build:production"
           }
         }
       },
@@ -110,7 +111,7 @@
         "continuous": true,
         "executor": "nx:run-commands",
         "options": {
-          "command": "npx nodemon --watch packages/catalog/src --ignore 'packages/reconciliation/dist/**' --ignore '**/node_modules/**' --ext 'ts,js,json' --exec 'npx nx serve-dev network-of-terms-reconciliation 2>&1 | grep -v \"catalog/\" | cat'"
+          "command": "npx nodemon --watch packages/catalog/src --ignore 'packages/reconciliation/dist/**' --ignore '**/node_modules/**' --ext 'ts,js,json' --exec 'npx nx serve-dev reconciliation 2>&1 | grep -v \"catalog/\" | cat'"
         }
       },
       "copy-workspace-modules": {},

--- a/packages/status/README.md
+++ b/packages/status/README.md
@@ -34,7 +34,7 @@ Then run the service:
     git clone https://github.com/netwerk-digitaal-erfgoed/network-of-terms.git
     cd network-of-terms
     npm install
-    npx nx serve network-of-terms-status
+    npx nx serve status
 
 ## Configuration
 

--- a/packages/status/package.json
+++ b/packages/status/package.json
@@ -35,6 +35,7 @@
     "node": ">=16.15.0"
   },
   "nx": {
+    "name": "status",
     "tags": [
       "release:docker"
     ],
@@ -91,15 +92,15 @@
           "build"
         ],
         "options": {
-          "buildTarget": "@netwerk-digitaal-erfgoed/network-of-terms-status:build",
+          "buildTarget": "status:build",
           "runBuildTargetDependencies": false
         },
         "configurations": {
           "development": {
-            "buildTarget": "@netwerk-digitaal-erfgoed/network-of-terms-status:build:development"
+            "buildTarget": "status:build:development"
           },
           "production": {
-            "buildTarget": "@netwerk-digitaal-erfgoed/network-of-terms-status:build:production"
+            "buildTarget": "status:build:production"
           }
         }
       }


### PR DESCRIPTION
Every scoped commit in this repository bumps **patch only**, whatever its conventional-commit type. `feat`, `feat!` and a `BREAKING CHANGE:` footer are all indistinguishable to `nx release`.

The cause is our own convention, not an nx bug: nx applies a commit’s *type* only to projects whose **name equals the commit scope**. The nx project names were the full npm package names (`@netwerk-digitaal-erfgoed/network-of-terms-catalog`), while we write `catalog`. They never match, so the commit still registered as “this project changed” through its changed files – hence a patch – but its type was discarded.

## Changes

- **Short nx project names** via `nx.name` in each `package.json`: `catalog`, `query`, `graphql`, `reconciliation`, `status`, `cli`. These are exactly the scopes in use (`git log` over the last 400 commits: `catalog` 34×, `query` 7×, `status` 6×, `graphql` 3×). The npm `name` fields are untouched, so nothing published changes and the inter-package `dependencies` keep resolving.
- **`releaseTag.pattern` prefixed with the npm scope** in both release groups: `@netwerk-digitaal-erfgoed/network-of-terms-{projectName}@{version}`. Combined with the short project names this reproduces the existing tag strings character-for-character, so version lineage is preserved and no retagging is needed. nx interpolates only `{version}`, `{projectName}` and `{releaseGroupName}`, so the literal prefix is the way to keep the tags stable.
- **Internal references updated**: the `buildTarget` options and the `serve`/`serve-dev` commands in the graphql, reconciliation and status projects addressed projects by their old names, as did `npx nx serve …` in `docs/docker.md` and the package READMEs.
- **`AGENTS.md` corrected.** It claimed project names were `network-of-terms-catalog` etc., which was wrong even before this change – the real names carried the `@netwerk-digitaal-erfgoed/` prefix, which is why `npx nx test network-of-terms-graphql` failed with “Cannot find configuration for task”. It now lists the real names and explains why the commit scope has to match them.

`.github/workflows/release.yml` needs no change: it matches on Docker image names, which come from `release.docker.repositoryName`, not from the project name.

## Verification

A probe commit `refactor(query)!:` touching `packages/query/` now dry-runs to the correct bump, resolving its current version from the pre-existing tag:

```
query 🏷️  Resolved the current version as 6.3.14 from git tag
        "@netwerk-digitaal-erfgoed/network-of-terms-query@6.3.14"
query 📄 Resolved the specifier as "major" using git history and the conventional commits standard
query ❓ Applied semver relative bump "major" … to get new version 7.0.0
```

Before this change the same commit produced 6.3.15.

This PR’s own commit is typed `build:`, so `nx release version --dry-run` reports no changes for either package – merging it publishes nothing.
