### PR TITLE
feat(catalog): return GeoNames labels in Dutch and English

### DIFF
--- a/packages/catalog/catalog/datasets/geonames-nl-be-de.jsonld
+++ b/packages/catalog/catalog/datasets/geonames-nl-be-de.jsonld
@@ -33,7 +33,7 @@
       "@value": "Selectie van geografische namen zoals plaatsen, administratieve eenheden (gemeentes, provincies) en waterlichamen (rivieren, beken, meren etc.)"
     }
   ],
-  "inLanguage": "en",
+  "inLanguage": ["nl", "en"],
   "distribution": [
     {
       "@id": "https://geonames.netwerkdigitaalerfgoed.nl#nl-be-de",

--- a/packages/catalog/catalog/datasets/geonames.jsonld
+++ b/packages/catalog/catalog/datasets/geonames.jsonld
@@ -34,7 +34,7 @@
       "@value": "Selectie van geografische namen zoals plaatsen, administratieve eenheden (gemeentes, provincies) en waterlichamen (rivieren, beken, meren etc.)"
     }
   ],
-  "inLanguage": "en",
+  "inLanguage": ["nl", "en"],
   "distribution": [
     {
       "@id": "https://geonames.netwerkdigitaalerfgoed.nl",

--- a/packages/catalog/catalog/queries/lookup/geonames.rq
+++ b/packages/catalog/catalog/queries/lookup/geonames.rq
@@ -5,7 +5,7 @@ PREFIX wgs84: <http://www.w3.org/2003/01/geo/wgs84_pos#>
 
 CONSTRUCT {
     ?uri a skos:Concept , schema:Place ;
-        skos:prefLabel ?prefLabel_ext ;
+        skos:prefLabel ?prefLabelNl , ?prefLabelEn , ?prefLabelFallback ;
         skos:altLabel ?altLabel ;
         skos:scopeNote ?scopeNote_en ;
         skos:broader ?broader ;
@@ -19,26 +19,112 @@ WHERE {
 
     # Every feature has exactly one point, including countries and continents.
     ?uri a gn:Feature ;
-        gn:name ?prefLabel ;
+        gn:name ?name ;
         wgs84:lat ?latitude ;
         wgs84:long ?longitude .
 
     # Supranational features (continents and the planet) have no country code.
     OPTIONAL { ?uri gn:countryCode ?countryCode . }
 
-    BIND(IF(BOUND(?countryCode), CONCAT(?prefLabel," (",UCASE(?countryCode),")"), ?prefLabel) as ?prefLabel_ext)
-
+    # One prefLabel per language this source declares (see inLanguage in the dataset description),
+    # so the API can hand each client the label in the language it asked for. gn:name carries no
+    # language by definition and is often the local or English form – ‘Federal Republic of Germany’
+    # rather than ‘Duitsland’ – so it is only the fallback.
+    #
+    # gn:officialName is GeoNames’ preferred name for a language and is rdfs:subPropertyOf
+    # skos:prefLabel. A name without that flag arrives as a language-tagged gn:alternateName, which
+    # is the only Dutch name for 98% of the features that have one, so both are needed.
+    #
+    # Take either only when GeoNames offers exactly one for the language: a few hundred features
+    # have several Dutch names with nothing to choose between them (‘Koudekerk a/d Rijn’ beside
+    # ‘Koudekerk aan de Rijn’), and those keep gn:name rather than an arbitrary variant.
     OPTIONAL {
-        ?uri gn:alternateName ?altLabel .
-        FILTER(?altLabel != "")
+        ?uri gn:officialName ?officialNameNl .
+        FILTER(LANG(?officialNameNl) = "nl")
+        FILTER NOT EXISTS {
+            ?uri gn:officialName ?otherOfficialNameNl .
+            FILTER(LANG(?otherOfficialNameNl) = "nl" && ?otherOfficialNameNl != ?officialNameNl)
+        }
+    }
+    OPTIONAL {
+        ?uri gn:alternateName ?alternateNameNl .
+        FILTER(LANG(?alternateNameNl) = "nl")
+        FILTER NOT EXISTS {
+            ?uri gn:alternateName ?otherAlternateNameNl .
+            FILTER(LANG(?otherAlternateNameNl) = "nl" && ?otherAlternateNameNl != ?alternateNameNl)
+        }
+    }
+    OPTIONAL {
+        ?uri gn:officialName ?officialNameEn .
+        FILTER(LANG(?officialNameEn) = "en")
+        FILTER NOT EXISTS {
+            ?uri gn:officialName ?otherOfficialNameEn .
+            FILTER(LANG(?otherOfficialNameEn) = "en" && ?otherOfficialNameEn != ?officialNameEn)
+        }
+    }
+    OPTIONAL {
+        ?uri gn:alternateName ?alternateNameEn .
+        FILTER(LANG(?alternateNameEn) = "en")
+        FILTER NOT EXISTS {
+            ?uri gn:alternateName ?otherAlternateNameEn .
+            FILTER(LANG(?otherAlternateNameEn) = "en" && ?otherAlternateNameEn != ?alternateNameEn)
+        }
+    }
+    BIND(COALESCE(?officialNameNl, ?alternateNameNl) AS ?prefLabelNlName)
+    BIND(COALESCE(?officialNameEn, ?alternateNameEn) AS ?prefLabelEnName)
+
+    # CONCAT keeps a language tag only when every argument carries the same one, so build the suffix
+    # separately and re-apply the tag with STRLANG. Without that the tag is lost and the API assumes
+    # the label is Dutch, which is the fallback that made an English name look Dutch to begin with.
+    # Where the name for a language is missing, STR() of the unbound variable raises an error and
+    # BIND leaves that prefLabel unbound, so no triple is produced for it.
+    BIND(IF(BOUND(?countryCode), CONCAT(" (", UCASE(?countryCode), ")"), "") AS ?countrySuffix)
+    BIND(STRLANG(CONCAT(STR(?prefLabelNlName), ?countrySuffix), "nl") AS ?prefLabelNl)
+    BIND(STRLANG(CONCAT(STR(?prefLabelEnName), ?countrySuffix), "en") AS ?prefLabelEn)
+    # Untagged, so a client asking for a language GeoNames has no name in still gets a label: the
+    # API returns untagged literals and treats them as Dutch.
+    BIND(CONCAT(STR(?name), ?countrySuffix) AS ?prefLabelFallback)
+
+    # gn:shortName, gn:colloquialName and gn:historicalName are rdfs:subPropertyOf gn:alternateName,
+    # but the store has no reasoner, so each has to be named. One UNION branch per property, since
+    # they are independently multi-valued. skos:prefLabel and skos:altLabel are disjoint, so leave
+    # out whichever names won a prefLabel above.
+    OPTIONAL {
+        { ?uri gn:alternateName ?altLabel }
+        UNION { ?uri gn:officialName ?altLabel }
+        UNION { ?uri gn:shortName ?altLabel }
+        UNION { ?uri gn:colloquialName ?altLabel }
+        UNION { ?uri gn:historicalName ?altLabel }
+        FILTER(!BOUND(?prefLabelNlName) || ?altLabel != ?prefLabelNlName)
+        FILTER(!BOUND(?prefLabelEnName) || ?altLabel != ?prefLabelEnName)
+        FILTER(?altLabel != ?name)
     }
 
     OPTIONAL {
         ?uri ?parents ?broader .
-        ?broader gn:name ?broader_prefLabel
+        ?broader gn:name ?broaderName .
         VALUES ?parents { gn:parentADM1 gn:parentADM2 }
         # filter out the circular links in the converted data
         FILTER(?uri != ?broader)
+        # Parents are labelled from gn:name too, so apply the same rule – otherwise a fixed
+        # 'Duitsland' would still sit under an untagged 'Provincie Zuid-Holland'.
+        OPTIONAL {
+            ?broader gn:officialName ?broaderOfficialNameNl .
+            FILTER(LANG(?broaderOfficialNameNl) = "nl")
+            FILTER NOT EXISTS {
+                ?broader gn:officialName ?otherBroaderOfficialNameNl .
+                FILTER(LANG(?otherBroaderOfficialNameNl) = "nl" && ?otherBroaderOfficialNameNl != ?broaderOfficialNameNl)
+            }
+        }
+        OPTIONAL {
+            ?broader gn:alternateName ?broaderAlternateNameNl .
+            FILTER(LANG(?broaderAlternateNameNl) = "nl")
+            FILTER NOT EXISTS {
+                ?broader gn:alternateName ?otherBroaderAlternateNameNl .
+                FILTER(LANG(?otherBroaderAlternateNameNl) = "nl" && ?otherBroaderAlternateNameNl != ?broaderAlternateNameNl)
+            }
+        }
+        BIND(COALESCE(?broaderOfficialNameNl, ?broaderAlternateNameNl, ?broaderName) AS ?broader_prefLabel)
     }
 
     OPTIONAL {

--- a/packages/catalog/catalog/queries/search/geonames.rq
+++ b/packages/catalog/catalog/queries/search/geonames.rq
@@ -7,7 +7,7 @@ PREFIX wgs84: <http://www.w3.org/2003/01/geo/wgs84_pos#>
 
 CONSTRUCT {
     ?uri a skos:Concept , schema:Place ;
-        skos:prefLabel ?prefLabel_ext ;
+        skos:prefLabel ?prefLabelNl , ?prefLabelEn , ?prefLabelFallback ;
         skos:altLabel ?altLabel ;
         skos:scopeNote ?scopeNote_en , ?scopeNote_nl ;
         skos:broader ?broader ;
@@ -44,11 +44,68 @@ WHERE {
     }
 
     # Every feature has exactly one point, including countries and continents.
-    ?uri gn:name ?prefLabel ;
+    ?uri gn:name ?name ;
         wgs84:lat ?latitude ;
         wgs84:long ?longitude .
 
-    BIND(IF(BOUND(?countryCode), CONCAT(?prefLabel," (",UCASE(?countryCode),")"), ?prefLabel) as ?prefLabel_ext)
+    # One prefLabel per language this source declares (see inLanguage in the dataset description),
+    # so the API can hand each client the label in the language it asked for. gn:name carries no
+    # language by definition and is often the local or English form – ‘Federal Republic of Germany’
+    # rather than ‘Duitsland’ – so it is only the fallback.
+    #
+    # gn:officialName is GeoNames’ preferred name for a language and is rdfs:subPropertyOf
+    # skos:prefLabel. A name without that flag arrives as a language-tagged gn:alternateName, which
+    # is the only Dutch name for 98% of the features that have one, so both are needed.
+    #
+    # Take either only when GeoNames offers exactly one for the language: a few hundred features
+    # have several Dutch names with nothing to choose between them (‘Koudekerk a/d Rijn’ beside
+    # ‘Koudekerk aan de Rijn’), and those keep gn:name rather than an arbitrary variant.
+    OPTIONAL {
+        ?uri gn:officialName ?officialNameNl .
+        FILTER(LANG(?officialNameNl) = "nl")
+        FILTER NOT EXISTS {
+            ?uri gn:officialName ?otherOfficialNameNl .
+            FILTER(LANG(?otherOfficialNameNl) = "nl" && ?otherOfficialNameNl != ?officialNameNl)
+        }
+    }
+    OPTIONAL {
+        ?uri gn:alternateName ?alternateNameNl .
+        FILTER(LANG(?alternateNameNl) = "nl")
+        FILTER NOT EXISTS {
+            ?uri gn:alternateName ?otherAlternateNameNl .
+            FILTER(LANG(?otherAlternateNameNl) = "nl" && ?otherAlternateNameNl != ?alternateNameNl)
+        }
+    }
+    OPTIONAL {
+        ?uri gn:officialName ?officialNameEn .
+        FILTER(LANG(?officialNameEn) = "en")
+        FILTER NOT EXISTS {
+            ?uri gn:officialName ?otherOfficialNameEn .
+            FILTER(LANG(?otherOfficialNameEn) = "en" && ?otherOfficialNameEn != ?officialNameEn)
+        }
+    }
+    OPTIONAL {
+        ?uri gn:alternateName ?alternateNameEn .
+        FILTER(LANG(?alternateNameEn) = "en")
+        FILTER NOT EXISTS {
+            ?uri gn:alternateName ?otherAlternateNameEn .
+            FILTER(LANG(?otherAlternateNameEn) = "en" && ?otherAlternateNameEn != ?alternateNameEn)
+        }
+    }
+    BIND(COALESCE(?officialNameNl, ?alternateNameNl) AS ?prefLabelNlName)
+    BIND(COALESCE(?officialNameEn, ?alternateNameEn) AS ?prefLabelEnName)
+
+    # CONCAT keeps a language tag only when every argument carries the same one, so build the suffix
+    # separately and re-apply the tag with STRLANG. Without that the tag is lost and the API assumes
+    # the label is Dutch, which is the fallback that made an English name look Dutch to begin with.
+    # Where the name for a language is missing, STR() of the unbound variable raises an error and
+    # BIND leaves that prefLabel unbound, so no triple is produced for it.
+    BIND(IF(BOUND(?countryCode), CONCAT(" (", UCASE(?countryCode), ")"), "") AS ?countrySuffix)
+    BIND(STRLANG(CONCAT(STR(?prefLabelNlName), ?countrySuffix), "nl") AS ?prefLabelNl)
+    BIND(STRLANG(CONCAT(STR(?prefLabelEnName), ?countrySuffix), "en") AS ?prefLabelEn)
+    # Untagged, so a client asking for a language GeoNames has no name in still gets a label: the
+    # API returns untagged literals and treats them as Dutch.
+    BIND(CONCAT(STR(?name), ?countrySuffix) AS ?prefLabelFallback)
 
     VALUES (?featureClass ?scopeNote_en ?scopeNote_nl) {
         (gn:A "Administrative boundary"@en "Bestuurlijke eenheid"@nl)
@@ -57,16 +114,45 @@ WHERE {
         (gn:P "Populated place"@en "Plaats"@nl)
     }
 
+    # gn:shortName, gn:colloquialName and gn:historicalName are rdfs:subPropertyOf gn:alternateName,
+    # but the store has no reasoner, so each has to be named. One UNION branch per property, since
+    # they are independently multi-valued. skos:prefLabel and skos:altLabel are disjoint, so leave
+    # out whichever names won a prefLabel above.
     OPTIONAL {
-        ?uri gn:alternateName ?altLabel .
-        FILTER(?altLabel != "")
+        { ?uri gn:alternateName ?altLabel }
+        UNION { ?uri gn:officialName ?altLabel }
+        UNION { ?uri gn:shortName ?altLabel }
+        UNION { ?uri gn:colloquialName ?altLabel }
+        UNION { ?uri gn:historicalName ?altLabel }
+        FILTER(!BOUND(?prefLabelNlName) || ?altLabel != ?prefLabelNlName)
+        FILTER(!BOUND(?prefLabelEnName) || ?altLabel != ?prefLabelEnName)
+        FILTER(?altLabel != ?name)
     }
 
     OPTIONAL {
         ?uri ?parents ?broader .
-        ?broader gn:name ?broader_prefLabel
+        ?broader gn:name ?broaderName .
         VALUES ?parents { gn:parentADM1 gn:parentADM2 }
         # filter out the circular links in the converted data
         FILTER(?uri != ?broader)
+        # Parents are labelled from gn:name too, so apply the same rule – otherwise a fixed
+        # 'Duitsland' would still sit under an untagged 'Provincie Zuid-Holland'.
+        OPTIONAL {
+            ?broader gn:officialName ?broaderOfficialNameNl .
+            FILTER(LANG(?broaderOfficialNameNl) = "nl")
+            FILTER NOT EXISTS {
+                ?broader gn:officialName ?otherBroaderOfficialNameNl .
+                FILTER(LANG(?otherBroaderOfficialNameNl) = "nl" && ?otherBroaderOfficialNameNl != ?broaderOfficialNameNl)
+            }
+        }
+        OPTIONAL {
+            ?broader gn:alternateName ?broaderAlternateNameNl .
+            FILTER(LANG(?broaderAlternateNameNl) = "nl")
+            FILTER NOT EXISTS {
+                ?broader gn:alternateName ?otherBroaderAlternateNameNl .
+                FILTER(LANG(?otherBroaderAlternateNameNl) = "nl" && ?otherBroaderAlternateNameNl != ?broaderAlternateNameNl)
+            }
+        }
+        BIND(COALESCE(?broaderOfficialNameNl, ?broaderAlternateNameNl, ?broaderName) AS ?broader_prefLabel)
     }
 }


### PR DESCRIPTION
GeoNames terms are served with `gn:name` as the `skos:prefLabel`. That property has no language tag by definition – the ontology says so: “the main international name of a feature. The value has no `xml:lang` tag”. `filterLiteralsByLanguage` treats an untagged literal as Dutch:

```ts
// If literal has no language tag, we assume it is in the Network of Terms’ default language, Dutch.
```

So `Federal Republic of Germany` was not merely the wrong label for Duitsland – it was returned to clients tagged `@nl`. Users then corrected it by hand in their CMS, which is what netwerk-digitaal-erfgoed/geonames-rdf#20 reports.

Both dataset entries meanwhile declare `"inLanguage": "en"`, which has never matched what the source returns either. netwerk-digitaal-erfgoed/geonames-rdf#42 republishes names from GeoNames’ `alternateNamesV2` table with a language tag, split over the ontology’s name properties, so the source can finally deliver what it declares.

## One prefLabel per declared language

`"inLanguage": ["nl", "en"]`, and a `skos:prefLabel` for each – built from `gn:officialName` for that language, else its unique `gn:alternateName`.

| | features with a usable name | via `officialName` | via unique `alternateName` | **prefLabel delivered** |
| --- | --- | --- | --- | --- |
| `nl` | 78,370 | 1,284 | 76,511 | **77,795** |
| `en` | 746,803 | 306,927 | 402,685 | **709,612** |

Both sources are needed per language: GeoNames sets `isPreferredName` for only 1,284 features in Dutch, while 76,511 carry their Dutch name as a plain alternate name.

Either is taken only when GeoNames offers exactly one for that language, enforced with `FILTER NOT EXISTS`. A few hundred features have several Dutch names with nothing to choose between them – `Koudekerk a/d Rijn` beside `Koudekerk aan de Rijn`, or four spellings of `Ouderkerk aan den IJssel`. Those keep `gn:name` rather than being handed an arbitrary variant; `MIN()` systematically prefers the abbreviated form, because `/` sorts below letters.

The untagged `gn:name` stays as a third prefLabel, so a client asking for a language GeoNames has no name in still gets a label instead of an empty field – the documented fallback, and what the 99.4% of features with no translated name rely on.

`STRLANG` re-applies the tag after the `(NL)` suffix is built: SPARQL `CONCAT` keeps a language tag only when every argument carries the same one, so without it the tag is dropped and the label is assumed Dutch all over again. Where a language has no name, `STR()` of the unbound variable raises an error and `BIND` leaves that prefLabel unbound, so no triple is emitted. (Removing the suffix in favour of structured data is netwerk-digitaal-erfgoed/network-of-terms#1514.)

The same Dutch-first rule applies to broader terms, which are labelled from `gn:name` too.

## altLabel

One `UNION` branch per name property. `gn:shortName`, `gn:colloquialName` and `gn:historicalName` are `rdfs:subPropertyOf gn:alternateName`, but the store runs no reasoner, so each has to be named or its names disappear from results. A historic name stays out of prefLabel by construction, since only the first two properties feed the per-language `COALESCE`.

Every name that won a prefLabel is excluded, since `skos:prefLabel` and `skos:altLabel` are disjoint in SKOS.

## Verified

Against a local Fuseki (production image, `tdb2.tdbloader` + `jena.textindexer`) holding the **new** data, then through `filterLiteralsByLanguage` itself:

| client asks | Germany | Koudekerke (no translated name) |
| --- | --- | --- |
| `nl` | `"Duitsland (DE)"@nl` | `"Koudekerke (NL)"@nl` |
| `en` | `"Germany (DE)"@en` | `"Koudekerke (NL)"@nl` |
| `de` (not declared) | `"Federal Republic of Germany (DE)"@nl` | `"Koudekerke (NL)"@nl` |
| `en,nl` | both, in preference order | `"Koudekerke (NL)"@nl` |
| no `languages` argument | `["Duitsland (DE)"]` | `["Koudekerke (NL)"]` |

**Safe to merge and deploy before the new data lands.** Every added clause is `OPTIONAL`, so on today’s data each per-language `COALESCE` stays unbound, only the untagged fallback is emitted, and the union degenerates to its `gn:alternateName` branch. Replaying this query against `master`’s over the **currently published** data, the only difference is altLabels that duplicated the prefLabel – nothing added, no ranking change, no change to any other property:

| query | triples removed | of which not an altLabel | added |
| --- | --- | --- | --- |
| Duitsland | 1 | 0 | 0 |
| Keulen | 2 | 0 | 0 |
| Brussel | 8 | 0 | 0 |
| Luik | 5 | 0 | 0 |
| Bergen | 3 | 0 | 0 |
| Koudekerke | 0 | 0 | 0 |
| Aken | 3 | 0 | 0 |
| Frankrijk | 4 | 0 | 0 |

One ordering constraint sits outside this repo: netwerk-digitaal-erfgoed/infrastructure#274 must be deployed before geonames-rdf publishes, or 565,670 names leave the Fuseki text index. It was merged and rolled out on 21 August.
