### PR TITLE
feat(catalog): return the GeoNames Wikidata alignment as skos:exactMatch

### DIFF
--- a/packages/catalog/catalog/queries/lookup/geonames.rq
+++ b/packages/catalog/catalog/queries/lookup/geonames.rq
@@ -9,6 +9,7 @@ CONSTRUCT {
         skos:altLabel ?altLabel ;
         skos:scopeNote ?scopeNote_en ;
         skos:broader ?broader ;
+        skos:exactMatch ?wikidataItem ;
         schema:latitude ?latitude ;
         schema:longitude ?longitude .
     ?broader skos:prefLabel ?broader_prefLabel .
@@ -25,6 +26,13 @@ WHERE {
 
     # Supranational features (continents and the planet) have no country code.
     OPTIONAL { ?uri gn:countryCode ?countryCode . }
+
+    # GeoNames aligns 1.1M features to Wikidata. The source publishes schema:sameAs rather than
+    # owl:sameAs, because 340 QIDs cover more than one feature – Wikidata models the three Tihange
+    # reactors as one power station – so the claim is deliberately non-entailing. Interchangeable
+    # for retrieval is exactly what skos:exactMatch asserts, which is also the only match predicate
+    # the API maps (see predicateToPropertyMap in @netwerk-digitaal-erfgoed/network-of-terms-query).
+    OPTIONAL { ?uri schema:sameAs ?wikidataItem } # Has no labels.
 
     # One prefLabel per language this source declares (see inLanguage in the dataset description),
     # so the API can hand each client the label in the language it asked for. gn:name carries no

--- a/packages/catalog/catalog/queries/search/geonames.rq
+++ b/packages/catalog/catalog/queries/search/geonames.rq
@@ -11,6 +11,7 @@ CONSTRUCT {
         skos:altLabel ?altLabel ;
         skos:scopeNote ?scopeNote_en , ?scopeNote_nl ;
         skos:broader ?broader ;
+        skos:exactMatch ?wikidataItem ;
         schema:latitude ?latitude ;
         schema:longitude ?longitude ;
         vrank:simpleRank ?score .
@@ -47,6 +48,14 @@ WHERE {
     ?uri gn:name ?name ;
         wgs84:lat ?latitude ;
         wgs84:long ?longitude .
+
+    # GeoNames aligns 1.1M features to Wikidata. The source publishes schema:sameAs rather than
+    # owl:sameAs, because 340 QIDs cover more than one feature – Wikidata models the three Tihange
+    # reactors as one power station – so the claim is deliberately non-entailing. Interchangeable
+    # for retrieval is exactly what skos:exactMatch asserts, which is also the only match predicate
+    # the API maps (see predicateToPropertyMap in @netwerk-digitaal-erfgoed/network-of-terms-query).
+    # Reconciliation runs through search rather than lookup, so this is the query that needs it.
+    OPTIONAL { ?uri schema:sameAs ?wikidataItem } # Has no labels.
 
     # One prefLabel per language this source declares (see inLanguage in the dataset description),
     # so the API can hand each client the label in the language it asked for. gn:name carries no


### PR DESCRIPTION
GeoNames aligns 1.1M features to Wikidata, in `alternateNamesV2` rows whose language code is the pseudo-code `wkdt`. netwerk-digitaal-erfgoed/geonames-rdf#44 starts publishing those as:

```
<https://sws.geonames.org/2921044/> <https://schema.org/sameAs> <http://www.wikidata.org/entity/Q183> .
```

Surface them as `skos:exactMatch`, in both `lookup/geonames.rq` and `search/geonames.rq`.

## Why the translation happens here

`predicateToPropertyMap` in `packages/query/src/terms.ts` is a closed allowlist, and `schema:sameAs` is not in it – an unmapped predicate is silently dropped. But that map only ever sees the CONSTRUCT output of a source query, never the source’s own vocabulary, which is why `gn:name`, `hg:Address` and `roar:documentedIn` are absent from it too. So the source query is the translation layer, and this needs no change in `query` or `graphql`. `adamlink-adressen.rq` already does the same for `owl:sameAs`.

## Why both queries

Reconciliation resolves a name string rather than a known URI, so search is the query that actually needs the QID; a client using lookup already holds the GeoNames URI. `47762b1` also set the precedent that the two files stay in lockstep.

## Why `skos:exactMatch` and not `rdfs:seeAlso`

The API renders `exactMatch` as a match with a resolved `prefLabel`, and `seeAlso` as a bare URI. The Wikidata URIs carry no labels in the GeoNames dataset – as with `adamlink-adressen` and `muziekschatten-personen` – and `mapRelatedTerms` already handles that with `term?.prefLabels ?? []`.

The source deliberately publishes the non-entailing `schema:sameAs` rather than `owl:sameAs`, because 340 QIDs cover more than one feature: Wikidata models the three Tihange reactors as one power station, and Batifa’s town, ADM3 and district as one place. `skos:exactMatch` asserts interchangeability for retrieval rather than identity of individuals, which is what that data supports. Both files carry a comment saying so.

## Deployment

Safe to merge and deploy before the new data lands. The added clause is `OPTIONAL`, so it stays unbound and no `exactMatch` is emitted until geonames-rdf next publishes, which happens on its Sunday 03:00 UTC harvest.
