### PR TITLE
fix(catalog): label GeoNames parents from gn:name again

### DIFF
--- a/packages/catalog/catalog/queries/search/geonames.rq
+++ b/packages/catalog/catalog/queries/search/geonames.rq
@@ -129,30 +129,20 @@ WHERE {
         FILTER(?altLabel != ?name)
     }
 
+    # Parents keep their untagged gn:name, unlike the features above. Labelling them per language
+    # means a second lookup on ?broader inside this OPTIONAL, and that is what ARQ cannot plan:
+    # a nested OPTIONAL – or any FILTER NOT EXISTS – on ?broader stops it running this block as a
+    # linear left-join with ?uri pushed in. It materialises the right-hand side instead, scanning
+    # all 22.5M parentADM1/parentADM2 triples rather than probing the ~100 URIs the subquery
+    # returned, and the query stops finishing: measured at 30s+ against 0.2s for this form, for
+    # every search term tried. Restore per-language parent labels only once ?broader can be
+    # labelled by a single lookup – see the note in the geonames-rdf issue on precomputing one
+    # skos:prefLabel per language at publish time.
     OPTIONAL {
         ?uri ?parents ?broader .
-        ?broader gn:name ?broaderName .
+        ?broader gn:name ?broader_prefLabel .
         VALUES ?parents { gn:parentADM1 gn:parentADM2 }
         # filter out the circular links in the converted data
         FILTER(?uri != ?broader)
-        # Parents are labelled from gn:name too, so apply the same rule – otherwise a fixed
-        # 'Duitsland' would still sit under an untagged 'Provincie Zuid-Holland'.
-        OPTIONAL {
-            ?broader gn:officialName ?broaderOfficialNameNl .
-            FILTER(LANG(?broaderOfficialNameNl) = "nl")
-            FILTER NOT EXISTS {
-                ?broader gn:officialName ?otherBroaderOfficialNameNl .
-                FILTER(LANG(?otherBroaderOfficialNameNl) = "nl" && ?otherBroaderOfficialNameNl != ?broaderOfficialNameNl)
-            }
-        }
-        OPTIONAL {
-            ?broader gn:alternateName ?broaderAlternateNameNl .
-            FILTER(LANG(?broaderAlternateNameNl) = "nl")
-            FILTER NOT EXISTS {
-                ?broader gn:alternateName ?otherBroaderAlternateNameNl .
-                FILTER(LANG(?otherBroaderAlternateNameNl) = "nl" && ?otherBroaderAlternateNameNl != ?broaderAlternateNameNl)
-            }
-        }
-        BIND(COALESCE(?broaderOfficialNameNl, ?broaderAlternateNameNl, ?broaderName) AS ?broader_prefLabel)
     }
 }


### PR DESCRIPTION
Both GeoNames sources currently report `TimeoutError: Source timed out after 20000ms` and show as down in the demonstrator. Every search times out; the SPARQL endpoint itself is healthy and answers a plain lookup in 60 ms.

## Cause

`feat(catalog): return GeoNames labels in Dutch and English` added per-language labels for the parent feature, which requires a second lookup on `?broader` inside the parent `OPTIONAL`:

```sparql
OPTIONAL {
    ?uri ?parents ?broader .
    ?broader gn:name ?broaderName .
    ...
    OPTIONAL { ?broader gn:officialName ?broaderOfficialNameNl . FILTER(LANG(...) = "nl") ... }
    OPTIONAL { ?broader gn:alternateName ?broaderAlternateNameNl . FILTER(LANG(...) = "nl") ... }
}
```

ARQ runs a simple `OPTIONAL` as a linear left-join with `?uri` pushed in, probing the ~100 URIs the subquery returned. Nesting an `OPTIONAL` inside it defeats that: the right-hand side is materialised instead, which means scanning all 22.5M `parentADM1`/`parentADM2` triples. The query stops finishing.

## What was measured

Searching `amsterdam`, worldwide, against the live endpoint:

| variant | result |
|---|---|
| deployed query | 503 after 30 s |
| without the four `FILTER NOT EXISTS` | 503 after 30 s |
| without the per-feature `?prefLabelNl` / `?prefLabelEn` clauses | 503 after 30 s |
| without the parent block entirely | 200 in 1.00 s |
| **parent labelled from `gn:name` (this PR)** | **200 in 0.18 s** |

So the language clauses are not the problem – they cost about 0.1 s. Nesting is. Confirmed from the other side too: the same block against `gn:countryCode` (13.4M triples, so not an empty-predicate effect) also times out, as do sibling `OPTIONAL`s, `UNION` branches with the uniqueness guard, and a fixed-predicate parent join.

This PR restores `gn:name` for parents rather than rephrasing the same lookup. Features keep their Dutch and English labels; only the parent reverts to an untagged label.

Timings with this change, across terms and both scopes: `amsterdam` 0.18 s worldwide / 0.13 s NL-BE-DE, `delft` 0.12 s, `duitsland` 0.27 s, `water` 0.74 s, `san` 0.85 s.

## Follow-up

Two things are worth doing before per-language parent labels come back:

1. **Re-measure after a reindex.** Every number above comes from an index that predates geonames-rdf#42 – `gn:officialName`, `shortName`, `colloquialName` and `historicalName` all count 0 there, because the load that would have brought them in failed on an unrelated image-policy bug (infrastructure#279). The plans may look different once the data matches what the query expects.
2. **Precompute the label.** Choosing one preferred label per language is a per-feature aggregate that the publisher can compute once per nightly build, instead of every client query re-deriving it with a negation. That would let both features and parents be labelled by a single lookup, and would make this class of timeout structurally impossible.
