### PR TITLE
chore: disable Nx usage analytics

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -123,5 +123,6 @@
       "publishable": true,
       "unitTestRunner": "vitest"
     }
-  }
+  },
+  "analytics": false
 }


### PR DESCRIPTION
Set `"analytics": false` in `nx.json`.

Nx 23 collects usage telemetry that is gated on exactly one thing – `isAnalyticsEnabled()` in `nx/dist/src/analytics/analytics.js` is `readNxJson()?.analytics === true`. There is no env var and no user-level config, so the workspace `nx.json` is the only place to answer the question.

Why pin it rather than rely on the current default:

- On an interactive terminal, Nx prompts “Share usage data with the Nx team?” whenever `analytics` is not already a boolean, and the prompt’s default is **yes** – pressing Enter enables it and writes the answer back to `nx.json`.
- The `update-22-6-0` migration runs the same prompt, so an `nx migrate` could flip it on.
- Checking the value in applies it to every contributor and every machine.

When enabled, Nx reports a workspace id (hash of the `origin` remote URL), a machine-derived user id, tool/OS versions, and the commands that were run.
