### PR TITLE
fix(catalog): stop GeoNames lookups timing out and restore parent languages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ cli ────────────┘
 ### Key Patterns
 
 - Terminology sources are defined as JSON-LD files in `packages/catalog/catalog/` with companion SPARQL query files
+- A source's `queries/search/` and `queries/lookup/` queries share most of their body: change them in tandem, and grep the other query files for the pattern you are fixing
 - SHACL schemas in `packages/catalog/shacl/` validate catalog entries
 - Environment validation uses `env-schema` (Fastify ecosystem)
 - Logging via Pino, metrics via OpenTelemetry

--- a/packages/catalog/catalog/queries/lookup/geonames.rq
+++ b/packages/catalog/catalog/queries/lookup/geonames.rq
@@ -108,31 +108,34 @@ WHERE {
         FILTER(?altLabel != ?name)
     }
 
+
+    # Parents are labelled in both languages the dataset declares, like the features above, but the
+    # branches are a UNION and
+    # carry no uniqueness guard, because neither a nested OPTIONAL nor a FILTER NOT EXISTS on
+    # ?broader can be planned here: either one stops ARQ running this block as a linear left-join
+    # with ?uri pushed in, so it materialises the right-hand side and scans all 22.5M
+    # parentADM1/parentADM2 triples. Measured against the live endpoint, every such variant took
+    # 30s+ where this one takes 0.1-0.4s – a single NOT EXISTS is enough to trip it.
+    #
+    # Without the guard a parent that has both a Dutch officialName and an untagged gn:name gets
+    # both as skos:prefLabel (‘Zuid-Holland’@nl beside ‘Provincie Zuid-Holland’). The API prefers a
+    # language-tagged literal over an untagged one, so Dutch clients see the tagged label; emitting
+    # one label per parent would need the negation this cannot afford, or a prefLabel precomputed
+    # per language in geonames-rdf.
     OPTIONAL {
         ?uri ?parents ?broader .
-        ?broader gn:name ?broaderName .
         VALUES ?parents { gn:parentADM1 gn:parentADM2 }
         # filter out the circular links in the converted data
         FILTER(?uri != ?broader)
-        # Parents are labelled from gn:name too, so apply the same rule – otherwise a fixed
-        # 'Duitsland' would still sit under an untagged 'Provincie Zuid-Holland'.
-        OPTIONAL {
-            ?broader gn:officialName ?broaderOfficialNameNl .
-            FILTER(LANG(?broaderOfficialNameNl) = "nl")
-            FILTER NOT EXISTS {
-                ?broader gn:officialName ?otherBroaderOfficialNameNl .
-                FILTER(LANG(?otherBroaderOfficialNameNl) = "nl" && ?otherBroaderOfficialNameNl != ?broaderOfficialNameNl)
-            }
-        }
-        OPTIONAL {
-            ?broader gn:alternateName ?broaderAlternateNameNl .
-            FILTER(LANG(?broaderAlternateNameNl) = "nl")
-            FILTER NOT EXISTS {
-                ?broader gn:alternateName ?otherBroaderAlternateNameNl .
-                FILTER(LANG(?otherBroaderAlternateNameNl) = "nl" && ?otherBroaderAlternateNameNl != ?broaderAlternateNameNl)
-            }
-        }
-        BIND(COALESCE(?broaderOfficialNameNl, ?broaderAlternateNameNl, ?broaderName) AS ?broader_prefLabel)
+        { ?broader gn:officialName ?broader_prefLabel . FILTER(LANG(?broader_prefLabel) = "nl") }
+        UNION
+        { ?broader gn:alternateName ?broader_prefLabel . FILTER(LANG(?broader_prefLabel) = "nl") }
+        UNION
+        { ?broader gn:officialName ?broader_prefLabel . FILTER(LANG(?broader_prefLabel) = "en") }
+        UNION
+        { ?broader gn:alternateName ?broader_prefLabel . FILTER(LANG(?broader_prefLabel) = "en") }
+        UNION
+        { ?broader gn:name ?broader_prefLabel . }
     }
 
     OPTIONAL {

--- a/packages/catalog/catalog/queries/search/geonames.rq
+++ b/packages/catalog/catalog/queries/search/geonames.rq
@@ -147,11 +147,33 @@ WHERE {
     # every search term tried. Restore per-language parent labels only once ?broader can be
     # labelled by a single lookup – see the note in the geonames-rdf issue on precomputing one
     # skos:prefLabel per language at publish time.
+
+    # Parents are labelled in both languages the dataset declares, like the features above, but the
+    # branches are a UNION and
+    # carry no uniqueness guard, because neither a nested OPTIONAL nor a FILTER NOT EXISTS on
+    # ?broader can be planned here: either one stops ARQ running this block as a linear left-join
+    # with ?uri pushed in, so it materialises the right-hand side and scans all 22.5M
+    # parentADM1/parentADM2 triples. Measured against the live endpoint, every such variant took
+    # 30s+ where this one takes 0.1-0.4s – a single NOT EXISTS is enough to trip it.
+    #
+    # Without the guard a parent that has both a Dutch officialName and an untagged gn:name gets
+    # both as skos:prefLabel (‘Zuid-Holland’@nl beside ‘Provincie Zuid-Holland’). The API prefers a
+    # language-tagged literal over an untagged one, so Dutch clients see the tagged label; emitting
+    # one label per parent would need the negation this cannot afford, or a prefLabel precomputed
+    # per language in geonames-rdf.
     OPTIONAL {
         ?uri ?parents ?broader .
-        ?broader gn:name ?broader_prefLabel .
         VALUES ?parents { gn:parentADM1 gn:parentADM2 }
         # filter out the circular links in the converted data
         FILTER(?uri != ?broader)
+        { ?broader gn:officialName ?broader_prefLabel . FILTER(LANG(?broader_prefLabel) = "nl") }
+        UNION
+        { ?broader gn:alternateName ?broader_prefLabel . FILTER(LANG(?broader_prefLabel) = "nl") }
+        UNION
+        { ?broader gn:officialName ?broader_prefLabel . FILTER(LANG(?broader_prefLabel) = "en") }
+        UNION
+        { ?broader gn:alternateName ?broader_prefLabel . FILTER(LANG(?broader_prefLabel) = "en") }
+        UNION
+        { ?broader gn:name ?broader_prefLabel . }
     }
 }


### PR DESCRIPTION
#1936 fixed the parent block in `queries/search/geonames.rq` and left the identical pattern in `queries/lookup/geonames.rq`. Lookups have been timing out ever since – 68 of them in the last twelve hours, each cut at exactly 30.0 s by the endpoint's `arq:queryTimeout`:

```
[1042] Query = CONSTRUCT { ?uri rdf:type skos:Concept … }   →  503 Service Unavailable (30.018 s)
[1055] …                                                     →  503 Service Unavailable (30.022 s)
[1059] …                                                     →  503 Service Unavailable (30.014 s)
```

Lookup backs the reconciliation API and the term detail view, so those were the requests failing while search looked healthy – which is why nothing pointed at the catalog.

## The constraint

Neither a nested `OPTIONAL` nor a `FILTER NOT EXISTS` on `?broader` can be planned inside the parent `OPTIONAL`. Either one stops ARQ running the block as a linear left-join with `?uri` pushed in: it materialises the right-hand side instead, scanning all 22.5M `parentADM1`/`parentADM2` triples rather than probing the URIs already in hand. Measured against the live endpoint on the current index:

| parent variant | lookup | search (`amsterdam`) |
|---|---|---|
| nested `OPTIONAL` (as deployed) | 503 @ 30.12 s | 503 @ 30.19 s |
| `UNION` with `NOT EXISTS` guards | 503 @ 30.07 s | 503 @ 30.29 s |
| `UNION`, two branches, one `NOT EXISTS` | 503 @ 30.07 s | – |
| **`UNION`, three branches, no guards** | **200 @ 0.07 s** | **200 @ 0.27 s** |

A single `NOT EXISTS` is enough to trip it, so this is categorical rather than a matter of degree.

## Changes

- **`lookup/geonames.rq`** – parent block becomes `UNION` branches: Dutch `officialName`, else Dutch `alternateName`, else `gn:name`. This is what stops the timeouts.
- **`search/geonames.rq`** – same block, which also **restores Dutch parent labels**, lost when #1936 reverted that query's parent to a bare `gn:name`.
- **`AGENTS.md`** – note that a source's search and lookup queries share most of their body and change in tandem. I grepped the rest of the catalog: no other query has this pattern.

Verified live after the change: lookup 0.07 s; search `delft` 0.12 s, `amsterdam` 0.27 s, `porto` 0.82 s. Catalog tests pass.

## Known trade-off

The branches carry no uniqueness guard, because the guard is exactly what cannot be planned. So a parent holding both a Dutch `officialName` and an untagged `gn:name` yields two `skos:prefLabel` values – `"Zuid-Holland"@nl` beside `"Provincie Zuid-Holland"`. The API prefers a language-tagged literal over an untagged one, so Dutch clients see the tagged label, but strictly this emits more than one preferred label per concept.

Emitting exactly one would need either the negation this shape cannot afford, or a `skos:prefLabel` precomputed per language in geonames-rdf. The latter is worth considering on its own merits: it would also let the *feature* labels drop their four `OPTIONAL`/`NOT EXISTS` blocks, moving a per-request computation to a once-nightly one. It is not a performance argument – measured warm, those clauses cost 3–7% of the query – but it removes a class of planner pathology this query has now demonstrated twice.
