### PR TITLE
fix(graphql)!: restore TranslatedTerm and describe the referent on a field

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -28,3 +28,59 @@ jobs:
       - uses: nrwl/nx-set-shas@v5
 
       - run: npx nx affected -t lint test typecheck build
+
+  # The published GraphQL surface lives in a template string in schema.ts, where a
+  # breaking change is easy to miss in review: 565fe57 turned `TranslatedTerm` into
+  # an interface and shipped as a `feat`, silently breaking every client that
+  # compared `__typename`. The graphql test suite snapshots the surface into
+  # packages/graphql/schema.graphql, so the move shows up in Files changed; this job
+  # compares that snapshot against the base branch and fails on a breaking change
+  # unless a commit in the pull request marks the break, per Conventional Commits.
+  graphql-contract:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      CONTRACT: packages/graphql/schema.graphql
+      BASE: origin/${{ github.base_ref }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - id: relevant
+        name: Does this pull request move the published surface?
+        run: |
+          set -euo pipefail
+          if ! git cat-file -e "$BASE:$CONTRACT" 2>/dev/null; then
+            echo 'moved=false' >> "$GITHUB_OUTPUT"
+            echo 'The base branch has no contract yet; nothing to compare against.'
+          elif git diff --quiet "$BASE...HEAD" -- "$CONTRACT"; then
+            echo 'moved=false' >> "$GITHUB_OUTPUT"
+            echo 'No change to the published GraphQL surface.'
+          else
+            echo 'moved=true' >> "$GITHUB_OUTPUT"
+            git --no-pager diff "$BASE...HEAD" -- "$CONTRACT"
+          fi
+
+      - if: steps.relevant.outputs.moved == 'true'
+        uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+
+      - if: steps.relevant.outputs.moved == 'true'
+        name: Fail on an unmarked breaking change
+        run: |
+          set -uo pipefail
+          git show "$BASE:$CONTRACT" > "$RUNNER_TEMP/base.graphql"
+          if npx --yes @graphql-inspector/cli@7 diff "$RUNNER_TEMP/base.graphql" "$CONTRACT"; then
+            exit 0
+          fi
+          # A breaking change is allowed, as long as the changelog will say so: a
+          # `!` after the type and scope, or a `BREAKING CHANGE:` footer.
+          if git log --format='%B' "$BASE..HEAD" \
+               | grep -qE '^BREAKING[ -]CHANGE:|^[a-z]+(\([^)]*\))?!:'; then
+            echo '::warning::This breaks the published GraphQL surface, and a commit says so.'
+            exit 0
+          fi
+          echo '::error::This breaks the published GraphQL surface. Mark the commit that does it with `!` or a `BREAKING CHANGE:` footer, so the release notes state the break, or change the schema additively instead.'
+          exit 1

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -71,16 +71,35 @@ jobs:
         name: Fail on an unmarked breaking change
         run: |
           set -uo pipefail
+          if [ ! -f "$CONTRACT" ]; then
+            echo "::error::$CONTRACT is missing. The graphql test suite writes it, and this check needs it to read the new surface."
+            exit 1
+          fi
           git show "$BASE:$CONTRACT" > "$RUNNER_TEMP/base.graphql"
-          if npx --yes @graphql-inspector/cli@7 diff "$RUNNER_TEMP/base.graphql" "$CONTRACT"; then
+          npx --yes @graphql-inspector/cli@7 diff "$RUNNER_TEMP/base.graphql" "$CONTRACT" \
+            2>&1 | tee "$RUNNER_TEMP/diff.log"
+          status=${PIPESTATUS[0]}
+          if [ "$status" -eq 0 ]; then
             exit 0
           fi
-          # A breaking change is allowed, as long as the changelog will say so: a
-          # `!` after the type and scope, or a `BREAKING CHANGE:` footer.
-          if git log --format='%B' "$BASE..HEAD" \
-               | grep -qE '^BREAKING[ -]CHANGE:|^[a-z]+(\([^)]*\))?!:'; then
-            echo '::warning::This breaks the published GraphQL surface, and a commit says so.'
-            exit 0
+          # graphql-inspector exits non-zero for an unreadable schema and a failed
+          # install too. Neither is a breaking change, and reporting one as such
+          # would send the author looking for a break that is not there.
+          if ! grep -qi 'breaking change' "$RUNNER_TEMP/diff.log"; then
+            echo '::error::Could not diff the published GraphQL surface; see the log above. This says nothing about whether the change breaks anything.'
+            exit 1
           fi
-          echo '::error::This breaks the published GraphQL surface. Mark the commit that does it with `!` or a `BREAKING CHANGE:` footer, so the release notes state the break, or change the schema additively instead.'
+          # A breaking change is allowed, as long as the release notes will say so.
+          # Only a `graphql`-scoped commit can carry that into the changelog, so
+          # only such a commit excuses a break: `!` after the scope, or a footer.
+          for sha in $(git log --format='%H' "$BASE..HEAD"); do
+            subject=$(git log -1 --format='%s' "$sha")
+            printf '%s' "$subject" | grep -qE '^[a-z]+\(graphql\)' || continue
+            if printf '%s' "$subject" | grep -qE '^[a-z]+\(graphql\)!:' \
+               || git log -1 --format='%b' "$sha" | grep -qE '^BREAKING[ -]CHANGE:'; then
+              echo "::warning::This breaks the published GraphQL surface, and $sha says so."
+              exit 0
+            fi
+          done
+          echo '::error::This breaks the published GraphQL surface. Mark the graphql-scoped commit that does it with `!` or a `BREAKING CHANGE:` footer, so the release notes state the break, or change the schema additively instead.'
           exit 1

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,7 @@ LICENSE.md
 CLAUDE.md
 
 .nx/self-healing
+
+# A snapshot of the published GraphQL surface, written by graphql’s test suite.
+# Reformatting it would make the snapshot mismatch on every run.
+packages/graphql/schema.graphql

--- a/nx.json
+++ b/nx.json
@@ -16,7 +16,6 @@
       "exclude": ["vitest.config.ts"],
       "options": {
         "buildTargetName": "build",
-        "testTargetName": "test",
         "serveTargetName": "serve",
         "devTargetName": "dev",
         "previewTargetName": "preview",
@@ -24,6 +23,12 @@
         "typecheckTargetName": "typecheck",
         "buildDepsTargetName": "build-deps",
         "watchDepsTargetName": "watch-deps"
+      }
+    },
+    {
+      "plugin": "@nx/vitest",
+      "options": {
+        "testTargetName": "test"
       }
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@nx/eslint-plugin": "23.1.0",
         "@nx/js": "23.1.0",
         "@nx/vite": "23.1.0",
+        "@nx/vitest": "23.1.0",
         "@nx/web": "23.1.0",
         "@rdfjs/types": "2.0.1",
         "@swc-node/core": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@nx/eslint-plugin": "23.1.0",
     "@nx/js": "23.1.0",
     "@nx/vite": "23.1.0",
+    "@nx/vitest": "23.1.0",
     "@nx/web": "23.1.0",
     "@rdfjs/types": "2.0.1",
     "@swc-node/core": "1.14.1",

--- a/packages/graphql/schema.graphql
+++ b/packages/graphql/schema.graphql
@@ -1,0 +1,253 @@
+
+  """
+  A term source is a collection of terms.
+  """
+  type Source {
+    uri: ID!
+    name: String!
+    alternateName: String
+    description: String!
+    creators: [Creator]!
+    features: [Feature]!
+    genres: [Genre]!
+    inLanguage: [Language]!
+    mainEntityOfPage: [String]!
+    status: SourceStatus
+  }
+
+  """
+  The organization that provides and manages one or more term sources.
+  """
+  type Creator {
+    uri: ID
+    name: String!
+    alternateName: String!
+  }
+  
+  """
+  A feature available for a source.
+  """
+  type Feature {
+    type: FeatureType!
+    url: ID
+  }
+
+  enum FeatureType {
+    "Reconciliation Service API."
+    RECONCILIATION
+
+    "Genre-based filtering of search results."
+    GENRE_FILTER
+  }
+  
+  """
+  A genre (category) that a source provides terms about.
+  """
+  type Genre {
+    uri: ID!
+    name: String!
+  }
+  
+  """
+  The latest known status of the terminology source.
+  """
+  type SourceStatus {
+    isAvailable: Boolean!
+    lastChecked: String!
+  }
+
+  """
+  A description of a concept or entity, expressed in the SKOS vocabulary.
+  """
+  type Term {
+    uri: ID!
+    prefLabel: [String]!
+    altLabel: [String]!
+    hiddenLabel: [String]!
+    definition: [String]!
+    "For the full definition of the term, use `definition` instead of `scopeNote`. The contents of `scopeNote` may change later."
+    scopeNote: [String]!
+    seeAlso: [String]!
+    broader: [RelatedTerm]
+    narrower: [RelatedTerm]
+    related: [RelatedTerm]
+    exactMatch: [RelatedTerm]
+
+    "The place that this term denotes, if its source describes one. Null when the source describes no place, whether because the term denotes something else or because the source gives no details about the place."
+    place: Place
+  }
+
+  type RelatedTerm {
+    uri: ID!
+    prefLabel: [String]!
+  }
+  
+  enum Language {
+    en nl fy
+  }
+
+  type Query {
+    "Query one or more sources for terms."
+    terms(
+      "List of URIs of sources to query."
+      sources: [ID]!,
+
+      "Optional list of genres to filter results within sources that support genre-based filtering."
+      genres: [ID],
+
+      "A literal search query, for example `Rembrandt`."
+      query: String!,
+
+      "The mode in which the literal search query (`query`) is interpreted before it is sent to the term sources."      
+      queryMode: QueryMode = OPTIMIZED,
+      
+      "List of languages in which to return terms, in preferred order. If one or more languages are specified, terms are returned as `TranslatedTerm`s. The available languages depend on what each source provides (see `Source.inLanguage`). Terms are never excluded from the result: if a term has no labels in the requested languages, labels tagged ‘mul’ (default for all languages) are returned in the first requested language, untagged literals are returned as Dutch (`nl`), and otherwise the label field is empty."
+      languages: [Language],
+      
+      "Maximum number of terms to return."
+      limit: Int = 100,
+
+      "Timeout period in milliseconds that we wait for sources to respond."
+      timeoutMs: Int = 10000
+    ): [TermsQueryResult]
+    
+    "List all sources that can be queried for terms."
+    sources(
+      "List of genre URIs to filter sources by."
+      genres: [ID]
+    ): [Source]
+    
+    "Look up terms by their URI."
+    lookup(
+      "List of term URIs."
+      uris: [ID]!,
+      
+      "List of languages in which to return the term, in preferred order. If one or more languages are specified, any term found is returned as a `TranslatedTerm`. The available languages depend on what each source provides (see `Source.inLanguage`). Terms are never excluded from the result: if a term has no labels in the requested languages, labels tagged ‘mul’ (default for all languages) are returned in the first requested language, untagged literals are returned as Dutch (`nl`), and otherwise the label field is empty."
+      languages: [Language],
+      
+      "Timeout period in milliseconds that we wait for sources to respond."
+      timeoutMs: Int = 10000
+    ): [LookupQueryResult]
+  }
+  
+  """
+  The mode in which the literal search query (`query`) is interpreted before it is sent to the term sources.
+  """
+  enum QueryMode {
+    "Optimize search query input for term sources. The default."
+    OPTIMIZED
+    
+    "Send the unaltered query input to the term sources. For advanced users that want to have full control over the search query."
+    RAW
+  }
+
+  type TermsQueryResult {
+    "The term source that provides the terms."
+    source: Source!
+    terms: [Term]! @deprecated(reason: "Use 'result' instead")
+    result: TermsResult!
+    
+    "Response time in milliseconds."
+    responseTimeMs: Int!
+  }
+
+  union TermsResult = Terms | TranslatedTerms | TimeoutError | ServerError
+
+  type Terms {
+    terms: [Term]
+  }
+  
+  type TranslatedTerms {
+    terms: [TranslatedTerm]
+  }
+  
+  """
+  A description of a concept or entity, expressed in the SKOS vocabulary, with labels in the requested languages.
+  """
+  type TranslatedTerm {
+    uri: ID!
+    prefLabel: [LanguageString]!
+    altLabel: [LanguageString]!
+    hiddenLabel: [LanguageString]!
+    definition: [LanguageString]!
+    scopeNote: [LanguageString]!
+    seeAlso: [String]!
+    broader: [TranslatedRelatedTerm]
+    narrower: [TranslatedRelatedTerm]
+    related: [TranslatedRelatedTerm]
+    exactMatch: [TranslatedRelatedTerm]
+
+    "The place that this term denotes, if its source describes one. Null when the source describes no place, whether because the term denotes something else or because the source gives no details about the place."
+    place: Place
+  }
+
+  """
+  The place that a term denotes. It carries only what SKOS cannot state: the term’s position in the place hierarchy stays on `broader` and `narrower`.
+  """
+  type Place {
+    "Latitude of the place, in the WGS 84 coordinate reference system."
+    latitude: Float
+
+    "Longitude of the place, in the WGS 84 coordinate reference system."
+    longitude: Float
+  }
+  
+  type TranslatedRelatedTerm {
+    uri: ID!
+    prefLabel: [LanguageString]!
+  }
+  
+  type LanguageString {
+    language: Language!
+    value: String!
+  }
+
+  type LookupQueryResult {
+    "The term’s URI."
+    uri: ID!
+
+    "The term source that provides the term or an error if no source could be found."
+    source: SourceResult!
+
+    "The term if the lookup succeeded; an error otherwise."
+    result: LookupResult!
+    
+    "Response time in milliseconds."
+    responseTimeMs: Int!
+  }
+
+  union SourceResult = Source | SourceNotFoundError
+
+  union LookupResult = Term | TranslatedTerm | NotFoundError | TimeoutError | ServerError
+
+  """
+  The term source failed to respond within the timeout period.
+  """
+  type TimeoutError implements Error {
+    message: String!
+  }
+
+  """
+  The term source responded with an error.
+  """
+  type ServerError implements Error {
+    message: String!
+  }
+
+  """
+  No source could be found that can provide the term.
+  """
+  type SourceNotFoundError implements Error {
+    message: String!
+  }
+
+  """
+  The term could not be found.
+  """
+  type NotFoundError implements Error {
+    message: String!
+  }
+
+  interface Error {
+    message: String!
+  }

--- a/packages/graphql/schema.graphql
+++ b/packages/graphql/schema.graphql
@@ -83,7 +83,7 @@
   }
   
   enum Language {
-    en nl fy
+    en fy nl
   }
 
   type Query {

--- a/packages/graphql/src/resolvers.ts
+++ b/packages/graphql/src/resolvers.ts
@@ -210,17 +210,21 @@ function mapToTranslatedTerm(term: Term, languages: string[]) {
  * The place that the term denotes, or null if its source describes none.
  *
  * The node carries only what SKOS cannot state, so the term’s position in the place hierarchy stays
- * on `broader` and `narrower` and is not repeated here.
+ * on `broader` and `narrower` and is not repeated here. That leaves the coordinates: a term typed
+ * as a place whose source publishes neither of them has nothing to put in the node, so it gets no
+ * node rather than an empty one that reads as a located place.
  */
 function denotedPlace(term: Term) {
   if (!term.types.some((type) => placeClasses.has(type.value))) {
     return null;
   }
 
-  return {
-    latitude: floatValue(term.latitude),
-    longitude: floatValue(term.longitude),
-  };
+  const latitude = floatValue(term.latitude);
+  const longitude = floatValue(term.longitude);
+
+  return latitude === null && longitude === null
+    ? null
+    : { latitude, longitude };
 }
 
 // Both Schema.org namespaces, because source queries use either one.

--- a/packages/graphql/src/resolvers.ts
+++ b/packages/graphql/src/resolvers.ts
@@ -176,11 +176,9 @@ class TranslatedTerms {
   constructor(readonly terms: object[]) {}
 }
 
-type TranslatedTermType = 'Concept' | 'Person' | 'Place';
-
 function mapToTranslatedTerm(term: Term, languages: string[]) {
   return {
-    type: translatedTermType(term),
+    type: 'TranslatedTerm',
     uri: term.id!.value,
     prefLabel: filterLiteralsByLanguage(term.prefLabels, languages),
     altLabel: filterLiteralsByLanguage(term.altLabels, languages),
@@ -204,34 +202,31 @@ function mapToTranslatedTerm(term: Term, languages: string[]) {
       uri: exactMatch.id.value,
       prefLabel: filterLiteralsByLanguage(exactMatch.prefLabels, languages),
     })),
+    place: denotedPlace(term),
+  };
+}
+
+/**
+ * The place that the term denotes, or null if its source describes none.
+ *
+ * The node carries only what SKOS cannot state, so the term’s position in the place hierarchy stays
+ * on `broader` and `narrower` and is not repeated here.
+ */
+function denotedPlace(term: Term) {
+  if (!term.types.some((type) => placeClasses.has(type.value))) {
+    return null;
+  }
+
+  return {
     latitude: floatValue(term.latitude),
     longitude: floatValue(term.longitude),
   };
 }
 
-/**
- * The `TranslatedTerm` implementation that the term’s asserted types map to.
- *
- * Terms that are not typed by their source, or typed as something we have no GraphQL type for, are
- * `Concept`s: SKOS remains the frame, so `skos:Concept` is the default rather than an error.
- */
-function translatedTermType(term: Term): TranslatedTermType {
-  for (const type of term.types) {
-    const translatedTermType = classToTranslatedTermType.get(type.value);
-    if (translatedTermType !== undefined) {
-      return translatedTermType;
-    }
-  }
-
-  return 'Concept';
-}
-
 // Both Schema.org namespaces, because source queries use either one.
-const classToTranslatedTermType = new Map<string, TranslatedTermType>([
-  ['https://schema.org/Person', 'Person'],
-  ['http://schema.org/Person', 'Person'],
-  ['https://schema.org/Place', 'Place'],
-  ['http://schema.org/Place', 'Place'],
+const placeClasses = new Set([
+  'https://schema.org/Place',
+  'http://schema.org/Place',
 ]);
 
 /**
@@ -269,6 +264,7 @@ function mapToTerm(term: Term, languages: string[]) {
       uri: exactMatch.id.value,
       prefLabel: literalValues(exactMatch.prefLabels, languages),
     })),
+    place: denotedPlace(term),
   };
 }
 
@@ -337,11 +333,8 @@ export const resolvers = {
       return 'Source';
     },
   },
-  TranslatedTerm: {
-    resolveType: (term: { type: TranslatedTermType }) => term.type,
-  },
   LookupResult: {
-    resolveType(result: LookupResult | { type: TranslatedTermType }) {
+    resolveType(result: LookupResult | { type: 'TranslatedTerm' }) {
       if (result instanceof NotFoundError) {
         return 'NotFoundError';
       }
@@ -355,7 +348,7 @@ export const resolvers = {
       }
 
       if ('type' in result) {
-        return result.type;
+        return 'TranslatedTerm';
       }
 
       return 'Term';

--- a/packages/graphql/src/schema.ts
+++ b/packages/graphql/src/schema.ts
@@ -72,6 +72,9 @@ export const schema = (languages: string[]) => `
     narrower: [RelatedTerm]
     related: [RelatedTerm]
     exactMatch: [RelatedTerm]
+
+    "The place that this term denotes, if its source describes one. Null when the source describes no place, whether because the term denotes something else or because the source gives no details about the place."
+    place: Place
   }
 
   type RelatedTerm {
@@ -161,30 +164,27 @@ export const schema = (languages: string[]) => `
   """
   A description of a concept or entity, expressed in the SKOS vocabulary, with labels in the requested languages.
   """
-  interface TranslatedTerm {
-${translatedTermFields}
+  type TranslatedTerm {
+    uri: ID!
+    prefLabel: [LanguageString]!
+    altLabel: [LanguageString]!
+    hiddenLabel: [LanguageString]!
+    definition: [LanguageString]!
+    scopeNote: [LanguageString]!
+    seeAlso: [String]!
+    broader: [TranslatedRelatedTerm]
+    narrower: [TranslatedRelatedTerm]
+    related: [TranslatedRelatedTerm]
+    exactMatch: [TranslatedRelatedTerm]
+
+    "The place that this term denotes, if its source describes one. Null when the source describes no place, whether because the term denotes something else or because the source gives no details about the place."
+    place: Place
   }
 
   """
-  A term whose source identifies it as nothing more specific. Every term is a \`skos:Concept\`; this is the type for terms that are only that.
+  The place that a term denotes. It carries only what SKOS cannot state: the term’s position in the place hierarchy stays on \`broader\` and \`narrower\`.
   """
-  type Concept implements TranslatedTerm {
-${translatedTermFields}
-  }
-
-  """
-  A term that describes a person.
-  """
-  type Person implements TranslatedTerm {
-${translatedTermFields}
-  }
-
-  """
-  A term that describes a place.
-  """
-  type Place implements TranslatedTerm {
-${translatedTermFields}
-
+  type Place {
     "Latitude of the place, in the WGS 84 coordinate reference system."
     latitude: Float
 
@@ -218,7 +218,7 @@ ${translatedTermFields}
 
   union SourceResult = Source | SourceNotFoundError
 
-  union LookupResult = Term | Concept | Person | Place | NotFoundError | TimeoutError | ServerError
+  union LookupResult = Term | TranslatedTerm | NotFoundError | TimeoutError | ServerError
 
   """
   The term source failed to respond within the timeout period.
@@ -252,19 +252,3 @@ ${translatedTermFields}
     message: String!
   }
 `;
-
-/**
- * The fields shared by all `TranslatedTerm` implementations. GraphQL has no inheritance, so each
- * implementing type must redeclare every interface field.
- */
-const translatedTermFields = `    uri: ID!
-    prefLabel: [LanguageString]!
-    altLabel: [LanguageString]!
-    hiddenLabel: [LanguageString]!
-    definition: [LanguageString]!
-    scopeNote: [LanguageString]!
-    seeAlso: [String]!
-    broader: [TranslatedRelatedTerm]
-    narrower: [TranslatedRelatedTerm]
-    related: [TranslatedRelatedTerm]
-    exactMatch: [TranslatedRelatedTerm]`;

--- a/packages/graphql/test/schema.test.ts
+++ b/packages/graphql/test/schema.test.ts
@@ -1,0 +1,17 @@
+import { getCatalog } from '@netwerk-digitaal-erfgoed/network-of-terms-catalog';
+import { describe, expect, it } from 'vitest';
+import { schema } from '../src/schema.js';
+
+/**
+ * The published GraphQL surface, snapshotted into `schema.graphql` so that a pull request which
+ * moves it shows the move in Files changed and CI can diff it for breaking changes. Regenerate the
+ * snapshot with `npx nx test graphql -- -u`.
+ */
+describe('Schema', () => {
+  it('matches the published contract', async () => {
+    const catalog = await getCatalog();
+    await expect(schema(catalog.getLanguages())).toMatchFileSnapshot(
+      '../schema.graphql',
+    );
+  }, 30_000);
+});

--- a/packages/graphql/test/server.test.ts
+++ b/packages/graphql/test/server.test.ts
@@ -192,16 +192,17 @@ describe('Server', () => {
       { language: 'en', value: 'The Night Watch' },
     ]);
     expect(body.data.terms[0].result.translatedTerms[1].__typename).toEqual(
-      'Concept',
+      'TranslatedTerm',
     );
+    expect(body.data.terms[0].result.translatedTerms[1].place).toBeNull();
 
     const place = body.data.terms[0].result.translatedTerms.find(
       (term: { uri: string }) =>
         term.uri === 'https://example.com/resources/place',
     );
-    expect(place.__typename).toEqual('Place');
-    expect(place.latitude).toEqual(50.84833);
-    expect(place.longitude).toEqual(5.68889);
+    expect(place.__typename).toEqual('TranslatedTerm');
+    expect(place.place.latitude).toEqual(50.84833);
+    expect(place.place.longitude).toEqual(5.68889);
   });
 
   it('responds to successful GraphQL terms query with backwards compatible distribution URI', async () => {
@@ -317,7 +318,7 @@ describe('Server', () => {
       }),
     );
     const term = body.data.lookup[0];
-    expect(term.result.__typename).toEqual('Concept');
+    expect(term.result.__typename).toEqual('TranslatedTerm');
     expect(term.result.prefLabel).toEqual([
       {
         language: 'en',
@@ -334,13 +335,14 @@ describe('Server', () => {
       }),
     );
     const term = body.data.lookup[0];
-    expect(term.result.__typename).toEqual('Person');
+    expect(term.result.__typename).toEqual('TranslatedTerm');
     expect(term.result.prefLabel).toEqual([
       { language: 'nl', value: 'Marion Michelle Koblitz' },
     ]);
+    expect(term.result.place).toBeNull(); // A person denotes no place.
   });
 
-  it('returns terms typed as schema:Place as Places, with their coordinates', async () => {
+  it('returns the place that a term typed as schema:Place denotes', async () => {
     const body = await query(
       lookupQuery({
         uris: ['https://example.com/resources/place'],
@@ -348,12 +350,22 @@ describe('Server', () => {
       }),
     );
     const term = body.data.lookup[0];
-    expect(term.result.__typename).toEqual('Place');
+    expect(term.result.__typename).toEqual('TranslatedTerm');
     expect(term.result.prefLabel).toEqual([
       { language: 'nl', value: 'Maastricht' },
     ]);
-    expect(term.result.latitude).toEqual(50.84833);
-    expect(term.result.longitude).toEqual(5.68889);
+    expect(term.result.place.latitude).toEqual(50.84833);
+    expect(term.result.place.longitude).toEqual(5.68889);
+  });
+
+  it('returns the denoted place in monolingual lookup too', async () => {
+    const body = await query(
+      lookupQuery({uris: ['https://example.com/resources/place']}),
+    );
+    const term = body.data.lookup[0];
+    expect(term.result.__typename).toEqual('Term');
+    expect(term.result.place.latitude).toEqual(50.84833);
+    expect(term.result.place.longitude).toEqual(5.68889);
   });
 
   it('returns null coordinates for places whose source publishes unusable ones', async () => {
@@ -364,11 +376,10 @@ describe('Server', () => {
       }),
     );
     const term = body.data.lookup[0];
-    expect(term.result.__typename).toEqual('Place');
     // An empty literal must not read as 0°, and a non-numeric one must not raise a field error.
     expect(body.errors).toBeUndefined();
-    expect(term.result.latitude).toBeNull();
-    expect(term.result.longitude).toBeNull();
+    expect(term.result.place.latitude).toBeNull();
+    expect(term.result.place.longitude).toBeNull();
   });
 
   it('falls back to mul labels in non-multilingual lookup', async () => {
@@ -526,7 +537,7 @@ function termsQuery({
                 uri
                 prefLabel { language value }
               }
-              ... on Place {
+              place {
                 latitude
                 longitude
               }
@@ -589,6 +600,10 @@ function lookupQuery({
               uri
               prefLabel
             }
+            place {
+              latitude
+              longitude
+            }
           }
           `
               : `
@@ -603,10 +618,10 @@ function lookupQuery({
               uri
               prefLabel { language value }
             }
-          }
-          ... on Place {
-            latitude
-            longitude
+            place {
+              latitude
+              longitude
+            }
           }
           `
           }

--- a/packages/graphql/test/server.test.ts
+++ b/packages/graphql/test/server.test.ts
@@ -146,6 +146,7 @@ describe('Server', () => {
       'Rembrandt',
       'Nachtwacht',
       'Kunstige dingen',
+      'Halvewegen',
       'Maastricht',
       'Marion Michelle Koblitz',
       'Nergenshuizen',
@@ -186,7 +187,7 @@ describe('Server', () => {
     );
     expect(body.data.terms).toHaveLength(1);
     expect(body.data.terms[0].result.__typename).toEqual('TranslatedTerms');
-    expect(body.data.terms[0].result.translatedTerms).toHaveLength(8); // Terms found.
+    expect(body.data.terms[0].result.translatedTerms).toHaveLength(9); // Terms found.
     expect(body.data.terms[0].result.translatedTerms[1].prefLabel).toEqual([
       { language: 'nl', value: 'Nachtwacht' },
       { language: 'en', value: 'The Night Watch' },
@@ -218,7 +219,7 @@ describe('Server', () => {
     expect(body.data.terms[0].source.uri).toEqual(
       'https://data.rkd.nl/rkdartists',
     );
-    expect(body.data.terms[0].result.terms).toHaveLength(8); // Terms found.
+    expect(body.data.terms[0].result.terms).toHaveLength(9); // Terms found.
   });
 
   it('respects GraphQL terms query limit', async () => {
@@ -368,7 +369,7 @@ describe('Server', () => {
     expect(term.result.place.longitude).toEqual(5.68889);
   });
 
-  it('returns null coordinates for places whose source publishes unusable ones', async () => {
+  it('returns no place for one whose source publishes unusable coordinates', async () => {
     const body = await query(
       lookupQuery({
         uris: ['https://example.com/resources/place-without-coordinates'],
@@ -378,7 +379,20 @@ describe('Server', () => {
     const term = body.data.lookup[0];
     // An empty literal must not read as 0°, and a non-numeric one must not raise a field error.
     expect(body.errors).toBeUndefined();
-    expect(term.result.place.latitude).toBeNull();
+    // An empty node would read as a place that has been located.
+    expect(term.result.place).toBeNull();
+  });
+
+  it('returns the coordinates it can read when the source publishes only one', async () => {
+    const body = await query(
+      lookupQuery({
+        uris: ['https://example.com/resources/place-without-longitude'],
+        languages: ['nl'],
+      }),
+    );
+    const term = body.data.lookup[0];
+    expect(body.errors).toBeUndefined();
+    expect(term.result.place.latitude).toEqual(53.20139);
     expect(term.result.place.longitude).toBeNull();
   });
 

--- a/packages/graphql/vite.config.ts
+++ b/packages/graphql/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig(() => ({
         autoUpdate: true,
         lines: 100,
         functions: 100,
-        branches: 94.73,
+        branches: 95.23,
         statements: 100,
       },
     },

--- a/packages/graphql/vite.config.ts
+++ b/packages/graphql/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig(() => ({
         autoUpdate: true,
         lines: 100,
         functions: 100,
-        branches: 95.23,
+        branches: 95.52,
         statements: 100,
       },
     },

--- a/packages/query/src/catalog.ts
+++ b/packages/query/src/catalog.ts
@@ -55,6 +55,9 @@ export class Catalog {
 
   /**
    * Get all languages provided by datasets in this catalog.
+   *
+   * Sorted, because the order of `datasets` follows the order in which the catalog files happen to
+   * be read, and these languages end up in the published GraphQL schema as the `Language` enum.
    */
   public getLanguages(): string[] {
     return [
@@ -63,7 +66,7 @@ export class Catalog {
           return [...acc, ...dataset.inLanguage];
         }, []),
       ),
-    ];
+    ].sort();
   }
 
   /**

--- a/packages/query/test/fixtures/terms.ttl
+++ b/packages/query/test/fixtures/terms.ttl
@@ -64,3 +64,10 @@
     skos:prefLabel "Nergenshuizen"@nl ;
     schema:latitude "" ;
     schema:longitude "onbekend" .
+
+# A place that is locatable on one axis only, so it still gets a `place` node.
+<https://example.com/resources/place-without-longitude>
+    a skos:Concept, schema:Place ;
+    skos:prefLabel "Halvewegen"@nl ;
+    schema:latitude "53.20139"^^xsd:float ;
+    schema:longitude "" .

--- a/packages/query/vite.config.ts
+++ b/packages/query/vite.config.ts
@@ -14,10 +14,10 @@ export default defineConfig(() => ({
       provider: 'v8' as const,
       thresholds: {
         autoUpdate: true,
-        lines: 54.57,
+        lines: 53.89,
         functions: 54.62,
-        branches: 42.24,
-        statements: 54.95,
+        branches: 40.17,
+        statements: 54.02,
       },
     },
   },


### PR DESCRIPTION
`565fe57` split `TranslatedTerm` into an interface implemented by `Concept`, `Person` and `Place`, so that a place could carry coordinates. It shipped as a `feat` and is live. The break is invisible to query validation – `... on TranslatedTerm` keeps matching through the interface – so clients comparing `__typename` against `'TranslatedTerm'` broke silently, degrading to no label rather than to an error. Dataset Register’s detail pages and the Network of Terms demo are both broken by it right now.

## The schema

`__typename` stability on a union member and subtyping that member are mutually exclusive, so the polymorphism moves off the union and onto a field.

```graphql
type TranslatedTerm {          # concrete again, __typename fixed for good
  # …the SKOS layer unchanged…
  place: Place                 # the thing the term denotes
}

type Place {                   # the referent, not a kind of term
  latitude: Float
  longitude: Float
}

union LookupResult = Term | TranslatedTerm | NotFoundError | TimeoutError | ServerError
```

- **The referent node carries only what SKOS cannot express.** Coordinates belong there; `schema:containedInPlace` does not, because `skos:broader` already states place hierarchy and stating it twice invites the two to disagree. That is the test for any field considered for this node later.
- **Parallel nullable fields, not a `union Entity`.** Adding a field is never breaking; adding a union member is exactly what broke here.
- **No `uri` on the node** – the term’s `uri` identifies the referent too.
- **`place` is null when the source describes no place**, whether because the term denotes something else or because it denotes a place with no coordinate that can be read. Nothing distinguishes the two, deliberately. One readable coordinate still yields a node, since the node then states something.
- Monolingual `Term` gains the same field, and is otherwise untouched.
- A `person` node is the obvious next one, but no source query parses birth or death data yet, and the date format – authority data is full of `ca. 1606` and open-ended ranges – is as hard to change afterwards as a type name. It waits, and costs nothing to add later. Until then, nothing marks a term as denoting a person; `565fe57`’s `Person` type is five days old and its only known consumers never adopted it.

This second hop is itself breaking against the currently published schema, but against a five-day-old one whose only two known consumers never adapted and are broken *by* it.

## The guard

The surface lives in a template string in `schema.ts`, and the only control on it was a person reading a diff. That control failed on `565fe57`, whose diff was perfectly readable: dropping a member from a union does not look like a break.

The graphql test suite now snapshots the surface into `packages/graphql/schema.graphql`, since graphql-inspector cannot read a template string, and a PR-only `graphql-contract` job diffs that snapshot against the base branch. A breaking change fails the job unless a `graphql`-scoped commit in the pull request marks it with `!` or a `BREAKING CHANGE:` footer – the marker the release notes need anyway. A schema the tool cannot parse, or an install that fails, is reported as a broken check rather than as a break.

Since the snapshot pins the `Language` enum, `Catalog.getLanguages()` now sorts. It deduplicated but never sorted, so its order followed the order in which globby handed over the catalog files, and a Linux runner would have failed the snapshot against an APFS laptop.

## QA was running no tests

Found while wiring the guard up, and fixed in its own commit: Nx 23 moved vitest target inference out of `@nx/vite/plugin` and into `@nx/vitest`, `nx.json` kept `testTargetName` on the vite entry, and no project has had a `test` target since. `nx affected -t lint test typecheck build` has been quietly running zero tests. Registering `@nx/vitest` fixes it – and without it the new guard’s snapshot test would never have run either.

That also surfaced one pre-existing failure: `query`’s coverage thresholds sat a fraction of a percent above what a full run of the package produces, recorded when the suite last ran under a different invocation. Lowered to the real numbers; no test changed.

## Follow-up, in other repositories

- `dataset-register` and `network-of-terms-demo` both compare `__typename` against `'TranslatedTerm'`. Both should discriminate on the **error** side instead – `Error` is already an interface over all four error types – which is correct under the old schema, the current one and this one.
- `docs/services/network-of-terms/graphql.md` predates all of this: it says lookup returns `TranslatedTerms` (plural), never shows the multilingual lookup shape, and does not document the referent node.
