### PR TITLE
fix(catalog): return every GeoNames name in a language as a prefLabel

### DIFF
--- a/packages/catalog/catalog/queries/lookup/geonames.rq
+++ b/packages/catalog/catalog/queries/lookup/geonames.rq
@@ -43,39 +43,40 @@ WHERE {
     # skos:prefLabel. A name without that flag arrives as a language-tagged gn:alternateName, which
     # is the only Dutch name for 98% of the features that have one, so both are needed.
     #
-    # Take either only when GeoNames offers exactly one for the language: a few hundred features
-    # have several Dutch names with nothing to choose between them (‘Koudekerk a/d Rijn’ beside
-    # ‘Koudekerk aan de Rijn’), and those keep gn:name rather than an arbitrary variant.
+    # GeoNames flags several names in one language for ~25 Dutch and ~8,266 English features
+    # – ‘Noord-Korea’ beside ‘Korea, Democratische Volksrepubliek’ – and its readme places no
+    # uniqueness constraint on isPreferredName, so all of them are returned. Picking one would need
+    # an aggregate or a negation over the names themselves; both pick arbitrarily and both are too
+    # slow, measured against the live endpoint at 24.2 s for MIN() and 9.09 s for SAMPLE(). Several
+    # preferred labels per language breach SKOS S14 in this query’s output, which is a validation
+    # nicety next to handing a Dutch client an English name, as dropping the language used to do.
+    #
+    # A language falls back to gn:alternateName only when GeoNames flagged no name for it. Without
+    # that guard ‘Holland’ and ‘Koninkrijk der Nederlanden’ would join ‘Nederland’ as preferred
+    # labels for the Netherlands. It sits in a plain OPTIONAL and tests ?uri, which is the shape
+    # ARQ pushes into; the same negation inside a UNION branch times out (see the parent block).
     OPTIONAL {
         ?uri gn:officialName ?officialNameNl .
         FILTER(LANG(?officialNameNl) = "nl")
-        FILTER NOT EXISTS {
-            ?uri gn:officialName ?otherOfficialNameNl .
-            FILTER(LANG(?otherOfficialNameNl) = "nl" && ?otherOfficialNameNl != ?officialNameNl)
-        }
     }
     OPTIONAL {
         ?uri gn:alternateName ?alternateNameNl .
         FILTER(LANG(?alternateNameNl) = "nl")
         FILTER NOT EXISTS {
-            ?uri gn:alternateName ?otherAlternateNameNl .
-            FILTER(LANG(?otherAlternateNameNl) = "nl" && ?otherAlternateNameNl != ?alternateNameNl)
+            ?uri gn:officialName ?anyOfficialNameNl .
+            FILTER(LANG(?anyOfficialNameNl) = "nl")
         }
     }
     OPTIONAL {
         ?uri gn:officialName ?officialNameEn .
         FILTER(LANG(?officialNameEn) = "en")
-        FILTER NOT EXISTS {
-            ?uri gn:officialName ?otherOfficialNameEn .
-            FILTER(LANG(?otherOfficialNameEn) = "en" && ?otherOfficialNameEn != ?officialNameEn)
-        }
     }
     OPTIONAL {
         ?uri gn:alternateName ?alternateNameEn .
         FILTER(LANG(?alternateNameEn) = "en")
         FILTER NOT EXISTS {
-            ?uri gn:alternateName ?otherAlternateNameEn .
-            FILTER(LANG(?otherAlternateNameEn) = "en" && ?otherAlternateNameEn != ?alternateNameEn)
+            ?uri gn:officialName ?anyOfficialNameEn .
+            FILTER(LANG(?anyOfficialNameEn) = "en")
         }
     }
     BIND(COALESCE(?officialNameNl, ?alternateNameNl) AS ?prefLabelNlName)
@@ -96,44 +97,52 @@ WHERE {
     # gn:shortName, gn:colloquialName and gn:historicalName are rdfs:subPropertyOf gn:alternateName,
     # but the store has no reasoner, so each has to be named. One UNION branch per property, since
     # they are independently multi-valued. skos:prefLabel and skos:altLabel are disjoint, so leave
-    # out whichever names won a prefLabel above.
+    # out the names that won a prefLabel above: every gn:officialName, and every name in one of the
+    # two languages this source declares for which GeoNames flagged none, since those all became
+    # prefLabels. Which of those two applies depends on the property a name came from, so the
+    # gn:alternateName branch flags itself and the language test applies to that branch alone,
+    # leaving a Dutch gn:shortName or gn:historicalName – ‘’s-Gravenhage’ – an altLabel whether
+    # or not GeoNames flagged a Dutch name. Official names in any other language stay altLabels
+    # too, since only these two languages get a prefLabel.
+    #
+    # The tests cannot compare with ?prefLabelNlName / ?prefLabelEnName, which now carry one row
+    # per name and would let the second name through on the row of the first. Nor can the branches
+    # test ?officialNameNl themselves: a FILTER inside a UNION branch that reads a variable bound
+    # outside it costs ARQ the push-down the parent block describes, measured at 30 s+ against
+    # 0.13 s for this form. A BIND is free, and a group-level filter reading it is too.
     OPTIONAL {
-        { ?uri gn:alternateName ?altLabel }
-        UNION { ?uri gn:officialName ?altLabel }
+        { ?uri gn:alternateName ?altLabel . BIND(true AS ?isAlternateName) }
+        UNION { ?uri gn:officialName ?altLabel . FILTER(LANG(?altLabel) NOT IN ("nl", "en")) }
         UNION { ?uri gn:shortName ?altLabel }
         UNION { ?uri gn:colloquialName ?altLabel }
         UNION { ?uri gn:historicalName ?altLabel }
-        FILTER(!BOUND(?prefLabelNlName) || ?altLabel != ?prefLabelNlName)
-        FILTER(!BOUND(?prefLabelEnName) || ?altLabel != ?prefLabelEnName)
         FILTER(?altLabel != ?name)
+        FILTER(!BOUND(?isAlternateName)
+            || LANG(?altLabel) NOT IN ("nl", "en")
+            || (LANG(?altLabel) = "nl" && BOUND(?officialNameNl))
+            || (LANG(?altLabel) = "en" && BOUND(?officialNameEn)))
     }
 
-
-    # Parents are labelled in both languages the dataset declares, like the features above, but the
-    # branches are a UNION and
-    # carry no uniqueness guard, because neither a nested OPTIONAL nor a FILTER NOT EXISTS on
-    # ?broader can be planned here: either one stops ARQ running this block as a linear left-join
-    # with ?uri pushed in, so it materialises the right-hand side and scans all 22.5M
+    # Parents are labelled in both languages the dataset declares, like the features above, but
+    # their branches carry no guard at all, because neither a nested OPTIONAL nor a FILTER NOT
+    # EXISTS on ?broader can be planned here: either one stops ARQ running this block as a linear
+    # left-join with ?uri pushed in, so it materialises the right-hand side and scans all 22.5M
     # parentADM1/parentADM2 triples. Measured against the live endpoint, every such variant took
-    # 30s+ where this one takes 0.1-0.4s – a single NOT EXISTS is enough to trip it.
+    # 30 s+ where this one takes 0.1–0.4 s – a single NOT EXISTS is enough to trip it.
     #
-    # Without the guard a parent that has both a Dutch officialName and an untagged gn:name gets
-    # both as skos:prefLabel (‘Zuid-Holland’@nl beside ‘Provincie Zuid-Holland’). The API prefers a
-    # language-tagged literal over an untagged one, so Dutch clients see the tagged label; emitting
-    # one label per parent would need the negation this cannot afford, or a prefLabel precomputed
-    # per language in geonames-rdf.
+    # So a parent gets every name GeoNames holds for it in Dutch and English, plus its untagged
+    # gn:name – ‘Zuid-Holland’@nl beside ‘Provincie Zuid-Holland’. The API prefers a
+    # language-tagged literal over an untagged one, so Dutch clients see the tagged label. What
+    # parents cannot have is the gn:officialName-over-gn:alternateName preference the features
+    # keep above; giving them one needs a skos:prefLabel precomputed per language in geonames-rdf.
     OPTIONAL {
         ?uri ?parents ?broader .
         VALUES ?parents { gn:parentADM1 gn:parentADM2 }
         # filter out the circular links in the converted data
         FILTER(?uri != ?broader)
-        { ?broader gn:officialName ?broader_prefLabel . FILTER(LANG(?broader_prefLabel) = "nl") }
+        { ?broader gn:officialName ?broader_prefLabel . FILTER(LANG(?broader_prefLabel) IN ("nl", "en")) }
         UNION
-        { ?broader gn:alternateName ?broader_prefLabel . FILTER(LANG(?broader_prefLabel) = "nl") }
-        UNION
-        { ?broader gn:officialName ?broader_prefLabel . FILTER(LANG(?broader_prefLabel) = "en") }
-        UNION
-        { ?broader gn:alternateName ?broader_prefLabel . FILTER(LANG(?broader_prefLabel) = "en") }
+        { ?broader gn:alternateName ?broader_prefLabel . FILTER(LANG(?broader_prefLabel) IN ("nl", "en")) }
         UNION
         { ?broader gn:name ?broader_prefLabel . }
     }
@@ -144,4 +153,8 @@ WHERE {
         BIND(STRLANG(?scopeNote, "en") as ?scopeNote_en)
     }
 }
-LIMIT 1000
+# One solution row per combination of name, altLabel and parent label, not one per term: a feature
+# like Nederland carries some 600 of them on its own, so the 1000 the other lookup queries use cut
+# a four-URI batch off mid-term – the trailing terms came back with part of their labels or none at
+# all. GraphQL lookup(uris:) takes an unbounded list, so keep a backstop, but one sized to rows.
+LIMIT 100000

--- a/packages/catalog/catalog/queries/search/geonames.rq
+++ b/packages/catalog/catalog/queries/search/geonames.rq
@@ -66,39 +66,40 @@ WHERE {
     # skos:prefLabel. A name without that flag arrives as a language-tagged gn:alternateName, which
     # is the only Dutch name for 98% of the features that have one, so both are needed.
     #
-    # Take either only when GeoNames offers exactly one for the language: a few hundred features
-    # have several Dutch names with nothing to choose between them (‘Koudekerk a/d Rijn’ beside
-    # ‘Koudekerk aan de Rijn’), and those keep gn:name rather than an arbitrary variant.
+    # GeoNames flags several names in one language for ~25 Dutch and ~8,266 English features
+    # – ‘Noord-Korea’ beside ‘Korea, Democratische Volksrepubliek’ – and its readme places no
+    # uniqueness constraint on isPreferredName, so all of them are returned. Picking one would need
+    # an aggregate or a negation over the names themselves; both pick arbitrarily and both are too
+    # slow, measured against the live endpoint at 24.2 s for MIN() and 9.09 s for SAMPLE(). Several
+    # preferred labels per language breach SKOS S14 in this query’s output, which is a validation
+    # nicety next to handing a Dutch client an English name, as dropping the language used to do.
+    #
+    # A language falls back to gn:alternateName only when GeoNames flagged no name for it. Without
+    # that guard ‘Holland’ and ‘Koninkrijk der Nederlanden’ would join ‘Nederland’ as preferred
+    # labels for the Netherlands. It sits in a plain OPTIONAL and tests ?uri, which is the shape
+    # ARQ pushes into; the same negation inside a UNION branch times out (see the parent block).
     OPTIONAL {
         ?uri gn:officialName ?officialNameNl .
         FILTER(LANG(?officialNameNl) = "nl")
-        FILTER NOT EXISTS {
-            ?uri gn:officialName ?otherOfficialNameNl .
-            FILTER(LANG(?otherOfficialNameNl) = "nl" && ?otherOfficialNameNl != ?officialNameNl)
-        }
     }
     OPTIONAL {
         ?uri gn:alternateName ?alternateNameNl .
         FILTER(LANG(?alternateNameNl) = "nl")
         FILTER NOT EXISTS {
-            ?uri gn:alternateName ?otherAlternateNameNl .
-            FILTER(LANG(?otherAlternateNameNl) = "nl" && ?otherAlternateNameNl != ?alternateNameNl)
+            ?uri gn:officialName ?anyOfficialNameNl .
+            FILTER(LANG(?anyOfficialNameNl) = "nl")
         }
     }
     OPTIONAL {
         ?uri gn:officialName ?officialNameEn .
         FILTER(LANG(?officialNameEn) = "en")
-        FILTER NOT EXISTS {
-            ?uri gn:officialName ?otherOfficialNameEn .
-            FILTER(LANG(?otherOfficialNameEn) = "en" && ?otherOfficialNameEn != ?officialNameEn)
-        }
     }
     OPTIONAL {
         ?uri gn:alternateName ?alternateNameEn .
         FILTER(LANG(?alternateNameEn) = "en")
         FILTER NOT EXISTS {
-            ?uri gn:alternateName ?otherAlternateNameEn .
-            FILTER(LANG(?otherAlternateNameEn) = "en" && ?otherAlternateNameEn != ?alternateNameEn)
+            ?uri gn:officialName ?anyOfficialNameEn .
+            FILTER(LANG(?anyOfficialNameEn) = "en")
         }
     }
     BIND(COALESCE(?officialNameNl, ?alternateNameNl) AS ?prefLabelNlName)
@@ -126,53 +127,52 @@ WHERE {
     # gn:shortName, gn:colloquialName and gn:historicalName are rdfs:subPropertyOf gn:alternateName,
     # but the store has no reasoner, so each has to be named. One UNION branch per property, since
     # they are independently multi-valued. skos:prefLabel and skos:altLabel are disjoint, so leave
-    # out whichever names won a prefLabel above.
+    # out the names that won a prefLabel above: every gn:officialName, and every name in one of the
+    # two languages this source declares for which GeoNames flagged none, since those all became
+    # prefLabels. Which of those two applies depends on the property a name came from, so the
+    # gn:alternateName branch flags itself and the language test applies to that branch alone,
+    # leaving a Dutch gn:shortName or gn:historicalName – ‘’s-Gravenhage’ – an altLabel whether
+    # or not GeoNames flagged a Dutch name. Official names in any other language stay altLabels
+    # too, since only these two languages get a prefLabel.
+    #
+    # The tests cannot compare with ?prefLabelNlName / ?prefLabelEnName, which now carry one row
+    # per name and would let the second name through on the row of the first. Nor can the branches
+    # test ?officialNameNl themselves: a FILTER inside a UNION branch that reads a variable bound
+    # outside it costs ARQ the push-down the parent block describes, measured at 30 s+ against
+    # 0.13 s for this form. A BIND is free, and a group-level filter reading it is too.
     OPTIONAL {
-        { ?uri gn:alternateName ?altLabel }
-        UNION { ?uri gn:officialName ?altLabel }
+        { ?uri gn:alternateName ?altLabel . BIND(true AS ?isAlternateName) }
+        UNION { ?uri gn:officialName ?altLabel . FILTER(LANG(?altLabel) NOT IN ("nl", "en")) }
         UNION { ?uri gn:shortName ?altLabel }
         UNION { ?uri gn:colloquialName ?altLabel }
         UNION { ?uri gn:historicalName ?altLabel }
-        FILTER(!BOUND(?prefLabelNlName) || ?altLabel != ?prefLabelNlName)
-        FILTER(!BOUND(?prefLabelEnName) || ?altLabel != ?prefLabelEnName)
         FILTER(?altLabel != ?name)
+        FILTER(!BOUND(?isAlternateName)
+            || LANG(?altLabel) NOT IN ("nl", "en")
+            || (LANG(?altLabel) = "nl" && BOUND(?officialNameNl))
+            || (LANG(?altLabel) = "en" && BOUND(?officialNameEn)))
     }
 
-    # Parents keep their untagged gn:name, unlike the features above. Labelling them per language
-    # means a second lookup on ?broader inside this OPTIONAL, and that is what ARQ cannot plan:
-    # a nested OPTIONAL – or any FILTER NOT EXISTS – on ?broader stops it running this block as a
-    # linear left-join with ?uri pushed in. It materialises the right-hand side instead, scanning
-    # all 22.5M parentADM1/parentADM2 triples rather than probing the ~100 URIs the subquery
-    # returned, and the query stops finishing: measured at 30s+ against 0.2s for this form, for
-    # every search term tried. Restore per-language parent labels only once ?broader can be
-    # labelled by a single lookup – see the note in the geonames-rdf issue on precomputing one
-    # skos:prefLabel per language at publish time.
-
-    # Parents are labelled in both languages the dataset declares, like the features above, but the
-    # branches are a UNION and
-    # carry no uniqueness guard, because neither a nested OPTIONAL nor a FILTER NOT EXISTS on
-    # ?broader can be planned here: either one stops ARQ running this block as a linear left-join
-    # with ?uri pushed in, so it materialises the right-hand side and scans all 22.5M
+    # Parents are labelled in both languages the dataset declares, like the features above, but
+    # their branches carry no guard at all, because neither a nested OPTIONAL nor a FILTER NOT
+    # EXISTS on ?broader can be planned here: either one stops ARQ running this block as a linear
+    # left-join with ?uri pushed in, so it materialises the right-hand side and scans all 22.5M
     # parentADM1/parentADM2 triples. Measured against the live endpoint, every such variant took
-    # 30s+ where this one takes 0.1-0.4s – a single NOT EXISTS is enough to trip it.
+    # 30 s+ where this one takes 0.1–0.4 s – a single NOT EXISTS is enough to trip it.
     #
-    # Without the guard a parent that has both a Dutch officialName and an untagged gn:name gets
-    # both as skos:prefLabel (‘Zuid-Holland’@nl beside ‘Provincie Zuid-Holland’). The API prefers a
-    # language-tagged literal over an untagged one, so Dutch clients see the tagged label; emitting
-    # one label per parent would need the negation this cannot afford, or a prefLabel precomputed
-    # per language in geonames-rdf.
+    # So a parent gets every name GeoNames holds for it in Dutch and English, plus its untagged
+    # gn:name – ‘Zuid-Holland’@nl beside ‘Provincie Zuid-Holland’. The API prefers a
+    # language-tagged literal over an untagged one, so Dutch clients see the tagged label. What
+    # parents cannot have is the gn:officialName-over-gn:alternateName preference the features
+    # keep above; giving them one needs a skos:prefLabel precomputed per language in geonames-rdf.
     OPTIONAL {
         ?uri ?parents ?broader .
         VALUES ?parents { gn:parentADM1 gn:parentADM2 }
         # filter out the circular links in the converted data
         FILTER(?uri != ?broader)
-        { ?broader gn:officialName ?broader_prefLabel . FILTER(LANG(?broader_prefLabel) = "nl") }
+        { ?broader gn:officialName ?broader_prefLabel . FILTER(LANG(?broader_prefLabel) IN ("nl", "en")) }
         UNION
-        { ?broader gn:alternateName ?broader_prefLabel . FILTER(LANG(?broader_prefLabel) = "nl") }
-        UNION
-        { ?broader gn:officialName ?broader_prefLabel . FILTER(LANG(?broader_prefLabel) = "en") }
-        UNION
-        { ?broader gn:alternateName ?broader_prefLabel . FILTER(LANG(?broader_prefLabel) = "en") }
+        { ?broader gn:alternateName ?broader_prefLabel . FILTER(LANG(?broader_prefLabel) IN ("nl", "en")) }
         UNION
         { ?broader gn:name ?broader_prefLabel . }
     }


### PR DESCRIPTION
#1938 stopped the lookup timeouts and gave parents a label in both languages. It left the *feature* labels as they were: each language takes a name only when GeoNames flags exactly one, and drops the language entirely when there are several. This finishes that job.

North Korea (`1873107`) is the case. GeoNames flags two Dutch official names for it, so the uniqueness guard rejected both and a Dutch client got `"North Korea (KP)"@en` and the untagged `"Democratic People’s Republic of Korea (KP)"` – the English formal name where a Dutch one exists. It now returns:

```
skos:prefLabel  "Noord-Korea (KP)"@nl , "Korea, Democratische Volksrepubliek (KP)"@nl ,
                "North Korea (KP)"@en , "Democratic People’s Republic of Korea (KP)"
```

~25 Dutch and ~8,266 English features have several names flagged in one language. GeoNames’ readme places no uniqueness constraint on `isPreferredName`, so returning all of them represents the data as published.

## Changes to `queries/{search,lookup}/geonames.rq`

- The four uniqueness guards per query are gone; every flagged name for a language becomes a `skos:prefLabel`.
- A language still falls back to `gn:alternateName` only when GeoNames flagged **no** name for it. Without that preference `Holland`, `Nederlanden` and `Koninkrijk der Nederlanden` would all become preferred labels for the Netherlands. The guard is a `FILTER NOT EXISTS` on `?uri` inside a plain `OPTIONAL`, which is the one position ARQ can plan.
- **`skos:altLabel`** now excludes prefLabel winners by the property a name came from: the `gn:alternateName` branch flags itself with a `BIND`, and the language test applies to that branch alone. So a Dutch `gn:shortName` or `gn:historicalName` – `’s-Gravenhage` – stays an altLabel whether or not GeoNames flagged a Dutch name, and official names in other languages (`"Corée du Nord"@fr`, `"Holanda"@es`) stay altLabels too, since only `nl` and `en` get a prefLabel. The old row-wise comparison with `?prefLabelNlName` / `?prefLabelEnName` no longer works: those variables now carry one row per name, so the second name would slip through on the first name’s row.
- **Lookup `LIMIT` raised to 100000.** It bounds *solution rows*, not terms, and a term’s rows are the product of its names, altLabels and parent labels – Nederland alone accounts for ~600. At 1000, a four-URI batch was cut off mid-term and the trailing terms came back with part of their labels or none at all; measured, that batch needs 1,306 rows. This already truncated on master at ~5 URIs, and `lookup(uris:)` takes an unbounded list, so the backstop is kept but sized to rows. The other lookup queries are left at 1000: GeoNames is the source with hundreds of labels per term.
- **Parent block** – five `UNION` branches collapse to three, the language test covering both declared languages at once. Same results, and it now matches the shape of the feature block.

## Planner constraints

The rule from #1938 – ARQ pushes `?uri` only down a linear chain of BGP + `OPTIONAL` – turns out to be sharper than “nothing on `?broader`”. Measured against the live endpoint on a four-URI lookup:

| shape | result |
|---|---|
| `FILTER NOT EXISTS` inside a `UNION` branch (constant language tag) | 503 @ 30.1 s |
| `FILTER` reading an outer `BOUND(…)` inside a `UNION` branch | 503 @ 30.2 s |
| `NOT EXISTS` over `gn:alternateName` at group level | 200 @ 1.7 s |
| **this PR** | **200 @ 0.16 s** |

So a `UNION` branch may only test its own variables; anything reading the surrounding scope has to be a group-level filter, and a `BIND` is the cheap way to carry provenance out to one. Search is unaffected: `delft` 0.11 s, `amsterdam` 0.39 s, `porto` 0.64 s.

## Known trade-offs

- A parent still gets every Dutch and English name GeoNames holds for it – `Leidschenveen`@nl appears beside `Den Haag`@nl on `Gemeente Den Haag`. That is #1938’s documented trade-off; removing it needs a `skos:prefLabel` precomputed per language in geonames-rdf.
- Several preferred labels per language breach SKOS S14 in this query’s output. Deliberate: a validation nicety against handing a Dutch client an English name.
- A name published under two properties (an `gn:alternateName` equal to a `gn:officialName` in the same language) can appear as both prefLabel and altLabel. Removing it needs a value-level `NOT EXISTS`, which is the 1.7 s row in the table above.
