### PR TITLE
fix(query): substitute bindings into the query instead of using initialBindings

### DIFF
--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "@comunica/query-sparql": "5.3.0",
     "@comunica/types": "5.3.0",
-    "@comunica/utils-bindings-factory": "5.3.0",
     "@hapi/hoek": "11.0.7",
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/exporter-metrics-otlp-proto": "0.221.0",
@@ -47,6 +46,7 @@
     "pino": "10.3.1",
     "pretty-ms": "9.3.0",
     "rdf-data-factory": "2.0.2",
+    "rdf-string-ttl": "^2.0.1",
     "spawnd": "11.0.0",
     "tslib": "2.8.1"
   },

--- a/packages/query/src/query.ts
+++ b/packages/query/src/query.ts
@@ -1,4 +1,5 @@
 import * as Hoek from '@hapi/hoek';
+import { termToString } from 'rdf-string-ttl';
 import Joi from 'joi';
 import { createLoggingFetch } from './helpers/logging-fetch.js';
 import { LoggerPino } from './helpers/logger-pino.js';
@@ -9,7 +10,6 @@ import { Term, TermsTransformer } from './terms.js';
 import { QueryMode, queryVariants } from './search/query-mode.js';
 import { Dataset, Distribution, IRI } from './catalog.js';
 import { QueryEngine } from '@comunica/query-sparql';
-import { BindingsFactory } from '@comunica/utils-bindings-factory';
 import { DataFactory } from 'rdf-data-factory';
 import { sourceQueriesHistogram } from './instrumentation.js';
 import { config } from './config.js';
@@ -71,9 +71,37 @@ export interface BuildSearchQueryResult {
 }
 
 /**
+ * Substitute bindings into the query text rather than passing them as Comunica initialBindings.
+ *
+ * Comunica materialises initialBindings by joining a VALUES clause into every FILTER operation,
+ * using all the bindings whether or not the sub-operation references them – so a query with two
+ * bindings arrives at the endpoint carrying six copies of each, including inside UNION branches
+ * that mention neither. Jena then stops pushing the bound variable into the branch and scans the
+ * predicate instead: measured against GeoNames, one such clause took a search from 0.21s to a 30s
+ * timeout. See https://github.com/comunica/comunica/issues/1759.
+ *
+ * Only searches carry bindings – lookup() interpolates its own IRIs – so this changes nothing for
+ * lookups. A previous version of this workaround existed for a crash (comunica#1655) and was
+ * removed once that was fixed; this one is about the query the endpoint receives.
+ */
+function substituteBindings(
+  query: string,
+  bindings: Record<string, RDF.Term>,
+): string {
+  let result = query;
+  for (const [name, term] of Object.entries(bindings)) {
+    result = result.replaceAll(
+      new RegExp(`\\?${name}\\b`, 'g'),
+      termToString(term),
+    );
+  }
+  return result;
+}
+
+/**
  * Build a SPARQL query and bindings from a template.
  * Returns the query with #LIMIT# replaced and a set of bindings for variables.
- * The bindings can be used with Comunica's initialBindings or serialized into the query.
+ * The bindings are substituted into the query text before it is sent; see substituteBindings().
  */
 export function buildSearchQuery(
   options: BuildSearchQueryOptions,
@@ -195,8 +223,9 @@ export class QueryTermsService {
     const logger = new LoggerPino({ logger: this.logger });
     // Extract HTTP credentials if the distribution URL contains any.
     const url = new URL(distribution.endpoint.toString());
-    this.logger.info(`Querying "${url}" with "${query}"...`);
-    const quadStream = await this.engine.queryQuads(query, {
+    const finalQuery = substituteBindings(query, bindings);
+    this.logger.info(`Querying "${url}" with "${finalQuery}"...`);
+    const quadStream = await this.engine.queryQuads(finalQuery, {
       log: logger,
       fetch: this.fetch,
       httpAuth:
@@ -209,7 +238,6 @@ export class QueryTermsService {
           value: url.origin + url.pathname,
         },
       ],
-      initialBindings: bindingsFactory.fromRecord(bindings),
     });
 
     return new Promise((resolve) => {
@@ -295,7 +323,6 @@ const alphabeticallyByLabels = (a: Term, b: Term) => {
 };
 
 const dataFactory = new DataFactory();
-const bindingsFactory = new BindingsFactory(dataFactory);
 
 const obfuscateHttpCredentials = (message: string) =>
   message.replace(/(https?):\/\/.+:.+@/, '$1://***@');

--- a/packages/query/test/query.test.ts
+++ b/packages/query/test/query.test.ts
@@ -10,7 +10,6 @@ import {
 } from '../src/index.js';
 import { QueryEngine } from '@comunica/query-sparql';
 import { ArrayIterator } from 'asynciterator';
-import type { Term } from '@rdfjs/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 function createTestDataset(
@@ -52,14 +51,30 @@ describe('Query', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
   });
-  it('passes dataset IRI query parameter to Comunica', async () => {
-    // Use GTAA which doesn't have VALUES, so uses initialBindings (not string substitution)
-    const config = await query(
-      'https://data.beeldengeluid.nl/id/datadownload/0026',
+  it('substitutes the dataset IRI into the query sent to Comunica', async () => {
+    await query('https://data.beeldengeluid.nl/id/datadownload/0026');
+    const sentQuery = comunicaMock.queryQuads.mock.calls[0][0];
+    expect(sentQuery).toContain(
+      '<http://data.beeldengeluid.nl/gtaa/Persoonsnamen>',
     );
-    expect(config.initialBindings.get('datasetUri')?.value).toEqual(
-      'http://data.beeldengeluid.nl/gtaa/Persoonsnamen',
+    expect(sentQuery).not.toContain('?datasetUri');
+  });
+
+  it('escapes a search term that would otherwise break the query', async () => {
+    const { dataset, distribution } = createTestDataset(
+      'CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?query }',
     );
+    await service.search(
+      'van "gogh" \\ x',
+      QueryMode.RAW,
+      dataset,
+      distribution,
+      10_000,
+      10_000,
+    );
+    const sentQuery = comunicaMock.queryQuads.mock.calls[0][0];
+    expect(sentQuery).toContain('"van \\"gogh\\" \\\\ x"');
+    expect(sentQuery).not.toContain('?query');
   });
 
   it('supports HTTP authentication', async () => {
@@ -95,7 +110,6 @@ const query = async (iri: string) => {
         value: string;
       },
     ];
-    initialBindings: Map<string, Term>;
   };
 };
 

--- a/packages/query/vite.config.ts
+++ b/packages/query/vite.config.ts
@@ -14,10 +14,10 @@ export default defineConfig(() => ({
       provider: 'v8' as const,
       thresholds: {
         autoUpdate: true,
-        lines: 70.32,
-        functions: 62.5,
+        lines: 70.67,
+        functions: 62.83,
         branches: 55.9,
-        statements: 70.17,
+        statements: 70.5,
       },
     },
   },


### PR DESCRIPTION
GeoNames *searches* have been timing out since the catalog fixes landed, and the catalog was never the problem: it is what Comunica adds to our queries on the way out.

(The lookup timeouts of 2026-08-24 were a different fault — the nested parent `OPTIONAL`, fixed in #1938. `lookup()` passes no bindings; it interpolates its own IRIs, so Comunica has nothing to inject and this PR does not affect it.)

`materializeOperation` joins a `VALUES` clause into **every `FILTER` operation**, built from *all* the initial bindings regardless of whether the sub-operation references them. Our two bindings (`?query`, `?datasetUri`) reach the endpoint as six copies each, including in UNION branches that mention neither:

```sparql
OPTIONAL {
  ?uri ?parents ?broader .
  { VALUES ?query { "depot" } VALUES ?datasetUri { <https://www.geonames.org> }   # <-- added by Comunica
    ?broader gn:officialName ?label . FILTER(LANG(?label) IN ("nl", "en")) }
  UNION
  { ?broader gn:name ?label }
}
```

Jena stops pushing `?broader` into a branch once it contains a `VALUES` join, and scans the predicate instead of probing the bound parents. Measured against the live endpoint, the same query with and without that single clause:

```
without:  200 in  0.21 s
with:     503 in 30.12 s
```

Everything else byte-identical. Reported upstream as comunica/comunica#1759.

## Changes

- **Substitute the bindings into the query text** instead of passing `initialBindings`. This restores the path #1714 removed, but unconditionally: the old `requiresStringSubstitution()` triggered on `SERVICE` or `VALUES` in the *source* query, and this injection happens at `FILTER`s, so that detection would miss it.
- **Escape the substituted literals.** The implementation removed in #1714 interpolated them raw (`"${term.value}"`), and the search term comes from the client – a quote or backslash would break the query or allow injection. There is now a test for it.

## Tests

`query` package: 33 passing. The dataset-IRI test asserted on `initialBindings`, which we no longer pass; it now asserts the IRI appears in the query sent and that `?datasetUri` does not survive. Added a test that a term containing `"` and `\` arrives escaped.

## Note

I could not build a runnable local reproduction: on `@comunica/query-sparql` 5.3.0, `initialBindings` against a `type: 'sparql'` source fails with `fetch failed` / `invalid content-length header` before any request is sent, while the same query without bindings works. Production evidently runs an older build, so this is worth knowing before the next upgrade – it may be a second, unrelated defect in the version already in `package.json`.
