### PR TITLE
fix(catalog): unbreak the IED lookup and guard against its cause

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23508,9 +23508,10 @@
       }
     },
     "node_modules/sparqljs": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.7.3.tgz",
-      "integrity": "sha512-FQfHUhfwn5PD9WH6xPU7DhFfXMgqK/XoDrYDVxz/grhw66Il0OjRg3JBgwuEvwHnQt7oSTiKWEiCZCPNaUbqgg==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.7.4.tgz",
+      "integrity": "sha512-hb4C84gf7KM7vz+iG595mPwvqxOvBJCm9L3dCxtV2zZDht6ZMmMG0tHeeqFeqwb9875yU9U4lhYe4LYRvWj0BQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT",
       "dependencies": {
         "rdf-data-factory": "^1.1.2"
@@ -25018,9 +25019,11 @@
         "@comunica/types": "5.3.0",
         "@types/n3": "1.26.1",
         "@types/rdf-ext": "2.5.2",
+        "@types/sparqljs": "^3.1.12",
         "jsonld-streaming-parser": "5.0.1",
         "rdf-ext": "2.6.0",
-        "rdf-validate-shacl": "0.6.5"
+        "rdf-validate-shacl": "0.6.5",
+        "sparqljs": "^3.7.4"
       }
     },
     "packages/cli": {

--- a/packages/catalog/catalog/queries/lookup/ied.rq
+++ b/packages/catalog/catalog/queries/lookup/ied.rq
@@ -1,4 +1,4 @@
-﻿PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
 CONSTRUCT {
     ?uri a skos:Concept ;

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -48,9 +48,11 @@
     "@comunica/types": "5.3.0",
     "@types/n3": "1.26.1",
     "@types/rdf-ext": "2.5.2",
+    "@types/sparqljs": "^3.1.12",
     "jsonld-streaming-parser": "5.0.1",
     "rdf-ext": "2.6.0",
-    "rdf-validate-shacl": "0.6.5"
+    "rdf-validate-shacl": "0.6.5",
+    "sparqljs": "^3.7.4"
   },
   "nx": {
     "name": "catalog",

--- a/packages/catalog/test/queries.test.ts
+++ b/packages/catalog/test/queries.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { Parser } from 'sparqljs';
+
+const queriesPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../catalog/queries',
+);
+
+const queryFiles = ['lookup', 'search'].flatMap((kind) =>
+  fs
+    .readdirSync(`${queriesPath}/${kind}`)
+    .filter((name) => name.endsWith('.rq'))
+    .map((name) => `${kind}/${name}`),
+);
+
+describe.each(queryFiles)('%s', (file) => {
+  const path = `${queriesPath}/${file}`;
+
+  /**
+   * A byte order mark is invisible in an editor and in a diff, but it is part of the query text we
+   * send: PoolParty answers a query that starts with one with an HTTP 400, which fails the whole
+   * GraphQL lookup rather than that one source. The IED lookup query carried one for two years.
+   */
+  it('starts with the query itself, not a byte order mark', () => {
+    const firstBytes = fs.readFileSync(path).subarray(0, 3);
+
+    expect([...firstBytes]).not.toEqual([0xef, 0xbb, 0xbf]);
+  });
+
+  /**
+   * Catches a prefix a query uses but never declares. Four queries carried one until the
+   * declarations were added, in the change that made lookups batch; this only keeps them from
+   * coming back. The failure is easy to miss because an endpoint that predefines the prefix
+   * answers anyway, so such a query works until it is pointed at one that does not - which is how
+   * Bibliotheken.nl and Muziekweb came to reject every lookup with ‘Undefined prefix’.
+   */
+  it('is a valid SPARQL query', () => {
+    // The placeholders the query service fills in; only these two sit where SPARQL wants a term
+    // rather than a variable, so the rest parse as they are.
+    const query = fs
+      .readFileSync(path, 'utf8')
+      .replaceAll('?uris', '<https://example.com/term>')
+      .replaceAll('?genres', '<https://example.com/genre>');
+
+    expect(() => new Parser().parse(query)).not.toThrow();
+  });
+});

--- a/packages/catalog/test/queries.test.ts
+++ b/packages/catalog/test/queries.test.ts
@@ -31,6 +31,17 @@ describe.each(queryFiles)('%s', (file) => {
   });
 
   /**
+   * The query service fills in `?uris` by string replacement, so a lookup query needs exactly one:
+   * a second would be left as an unbound variable, and `VALUES ?uri { ?uris }` then joins against
+   * every term the source holds rather than failing.
+   */
+  it.runIf(file.startsWith('lookup/'))('names ?uris exactly once', () => {
+    const occurrences = fs.readFileSync(path, 'utf8').match(/\?uris\b/g) ?? [];
+
+    expect(occurrences).toHaveLength(1);
+  });
+
+  /**
    * Catches a prefix a query uses but never declares. Four queries carried one until the
    * declarations were added, in the change that made lookups batch; this only keeps them from
    * coming back. The failure is easy to miss because an endpoint that predefines the prefix


### PR DESCRIPTION
A lookup of any IED term fails in production, and has since the source was added:

```
$ curl -s https://termennetwerk-api.netwerkdigitaalerfgoed.nl/graphql \
    -H 'content-type: application/json' \
    -d '{"query":"{ lookup(uris: [\"https://data.indischherinneringscentrum.nl/ied/110950\"]) { uri result { __typename } } }"}'

{"data":{"lookup":null},"errors":[{"message":"unexpected character: ->﻿<- at offset: 0, skipped 0 characters.", ... ,"path":["lookup"]}]}
```

`queries/lookup/ied.rq` starts with a UTF-8 byte order mark. It was there in the commit that added the file (`494881b`, March 2024) and has survived every commit since, including the move to `packages/catalog`. Its sibling `queries/search/ied.rq`, added in the same PR, does not have one – which is why IED search works and only lookup is broken.

Two things kept it quiet: the failure is a top-level GraphQL error rather than an `Error` in that source’s results, so it reads like a malformed request; and it takes the whole field down, so a batch containing one IED URI returns `null` for every other URI in it too.

## The guard

Neither `sparqljs` nor `sparqlalgebrajs` objects to a BOM – it is PoolParty that refuses the query:

```
POST …/PoolParty/sparql/ied   with BOM → HTTP 400
POST …/PoolParty/sparql/ied   without  → HTTP 200
```

So the test asserts on the bytes rather than on a parse. Alongside it, every query file is parsed with `sparqljs`, which catches a prefix a query uses but never declares – the other class of bug that shipped unnoticed, because an endpoint that predefines the prefix answers anyway. Both checks fail when their bug is reintroduced.

`sparqljs` was already in the tree through `sparqlalgebrajs`; this promotes it to a direct devDependency of the package that uses it.

## Merge order

Based on #1946, which declares the missing prefixes – the parse check does not pass without it. GitHub will retarget this to `master` once that merges.
