### PR TITLE
build(deps): update fetch-sparql-endpoint to 7.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17810,9 +17810,9 @@
       }
     },
     "node_modules/fetch-sparql-endpoint": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-7.1.0.tgz",
-      "integrity": "sha512-+C5x3uOqumCvyqDkwXZ31len8qsNfBERWvL6ngqO4m1PSmfqmut4A+2bBbBln48Ag4qudUrG+9qZjFvzY66ubw==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-7.1.2.tgz",
+      "integrity": "sha512-Z1Q+3yeXDaSqRHkLUrmU1TtITaeVRABYUT074vcBuUJdd0PaRefRVcVpiWzuFwWCrH1YTPwGE7VkIiFhkZ731Q==",
       "license": "MIT",
       "dependencies": {
         "@traqula/parser-sparql-1-2": "^1.0.0",


### PR DESCRIPTION
A SPARQL endpoint that answers `200 OK` and then drops the connection halfway through the response body used to kill the API process. The error was emitted on the response body stream, which nothing was listening to, so Node threw – and every request in flight died with it, whatever source it was for. Getty does this to a lookup batch that runs past its budget, so it is reachable from a normal request.

`fetch-sparql-endpoint` 7.1.2 forwards those errors to the triple stream, where the query service already handles them. Reported as comunica/comunica#1773 with a 20-line reproduction and fixed the same day by @rubensworks (rubensworks/fetch-sparql-endpoint.js@f3cdccc).

Comunica asks for `^7.1.0`, so this needs no Comunica release – only our lockfile pinned the old version.

## Verified

Same request against a local server, before and after, with the lookup batch size raised to 40 so that Getty cuts the response:

| | before | after |
| --- | --- | --- |
| response | connection dropped | `ServerError` for each of the 40 URIs |
| process | exits, `Unhandled 'error' event` | still serving |

The standalone reproduction from the issue behaves the same way: process exit before, `error handler called: terminated` after.

Batch size stays at 25 here, so this is not a fix for anything currently reachable in production – it removes the failure mode that made an oversized batch fatal rather than slow. It also unblocks retrying a failed batch in smaller pieces, which needs the failure to be catchable.
