### PR TITLE
feat(catalog): add The House of Legacies persons

### DIFF
--- a/packages/catalog/catalog/datasets/hol-persons.jsonld
+++ b/packages/catalog/catalog/datasets/hol-persons.jsonld
@@ -1,0 +1,67 @@
+{
+  "@context": "https://schema.org",
+  "@id": "https://terms.thehouseoflegacies.nl/dataset/persons",
+  "@type": "Dataset",
+  "name": [
+    {
+      "@language": "en",
+      "@value": "The House of Legacies: Persons"
+    },
+    {
+      "@language": "nl",
+      "@value": "The House of Legacies: Personen"
+    }
+  ],
+  "genre": [
+    {
+      "@id": "https://data.cultureelerfgoed.nl/termennetwerk/onderwerpen/Personen"
+    }
+  ],
+  "creator": [
+    {
+      "@id": "https://www.thehouseoflegacies.nl/"
+    }
+  ],
+  "url": ["https://pid.thehouseoflegacies.nl/ark:43442/"],
+  "mainEntityOfPage": ["https://terms.thehouseoflegacies.nl/dataset/persons"],
+  "description": [
+    {
+      "@language": "en",
+      "@value": "Makers, performers and other contributors to the Dutch performing arts, taken from the archive of The House of Legacies, an inclusive archive of the legacies of performing artists of colour. Each person is linked to the productions, groups and archival records that document their work, from artists born in the late nineteenth century to makers active today."
+    },
+    {
+      "@language": "nl",
+      "@value": "Makers, uitvoerders en andere bijdragers aan de Nederlandse podiumkunsten, afkomstig uit het archief van The House of Legacies, een inclusief archief van de nalatenschappen van podiumkunstenaars van kleur. Elk persoon is verbonden aan de voorstellingen, gezelschappen en archiefstukken die het werk documenteren, van kunstenaars geboren in de late negentiende eeuw tot makers die vandaag actief zijn."
+    }
+  ],
+  "inLanguage": "nl",
+  "distribution": [
+    {
+      "@id": "https://terms.thehouseoflegacies.nl/query",
+      "@type": "DataDownload",
+      "contentUrl": "https://terms.thehouseoflegacies.nl/query",
+      "encodingFormat": "application/sparql-query",
+      "potentialAction": [
+        {
+          "@type": "SearchAction",
+          "query": "file://../queries/search/hol-persons.rq"
+        },
+        {
+          "@type": "FindAction",
+          "query": "file://../queries/lookup/hol-persons.rq"
+        },
+        {
+          "@type": "Action",
+          "target": {
+            "@type": "EntryPoint",
+            "actionApplication": {
+              "@id": "https://reconciliation-api.github.io/specs/latest/",
+              "@type": "SoftwareApplication"
+            },
+            "urlTemplate": "https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{dataset}"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/catalog/catalog/publishers.jsonld
+++ b/packages/catalog/catalog/publishers.jsonld
@@ -385,6 +385,21 @@
         }
       ],
       "alternateName": "Korpora"
+    },
+    {
+      "@id": "https://www.thehouseoflegacies.nl/",
+      "@type": "Organization",
+      "name": [
+        {
+          "@language": "en",
+          "@value": "The House of Legacies"
+        },
+        {
+          "@language": "nl",
+          "@value": "The House of Legacies"
+        }
+      ],
+      "alternateName": "House of Legacies"
     }
   ]
 }

--- a/packages/catalog/catalog/queries/lookup/hol-persons.rq
+++ b/packages/catalog/catalog/queries/lookup/hol-persons.rq
@@ -1,0 +1,28 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+CONSTRUCT {
+    ?uri a skos:Concept ;
+        skos:prefLabel ?prefLabel ;
+        skos:altLabel ?altLabel ;
+        skos:scopeNote ?scopeNote ;
+        skos:exactMatch ?exactMatch_uri ;
+        skos:inScheme ?datasetUri .
+}
+WHERE {
+    VALUES ?uri { ?uris }
+    VALUES ?datasetUri { <https://terms.thehouseoflegacies.nl/dataset/persons> }
+
+    ?uri a skos:Concept .
+
+    # One UNION branch per independently multi-valued property, and not an OPTIONAL group:
+    # see “One UNION branch per multi-valued property” in the catalog README.
+    {
+        { ?uri a skos:Concept }
+        UNION { ?uri skos:prefLabel ?prefLabel }
+        UNION { ?uri skos:altLabel ?altLabel }
+        UNION { ?uri skos:scopeNote ?scopeNote }
+        UNION { ?uri owl:sameAs ?exactMatch_uri } # Has no labels.
+    }
+}
+LIMIT 10000

--- a/packages/catalog/catalog/queries/search/hol-persons.rq
+++ b/packages/catalog/catalog/queries/search/hol-persons.rq
@@ -1,0 +1,35 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+CONSTRUCT {
+    ?uri a skos:Concept ;
+        skos:prefLabel ?prefLabel ;
+        skos:altLabel ?altLabel ;
+        skos:scopeNote ?scopeNote ;
+        skos:exactMatch ?exactMatch_uri .
+}
+WHERE {
+    {
+        SELECT DISTINCT ?uri WHERE {
+            ?uri a skos:Concept ;
+                skos:inScheme <https://terms.thehouseoflegacies.nl/scheme/persons> ;
+                ?labelPredicate ?label .
+
+            # skos:hiddenLabel carries diacritic-folded forms, so “israels” matches “Israëls”.
+            VALUES ?labelPredicate { skos:prefLabel skos:altLabel skos:hiddenLabel }
+
+            FILTER(CONTAINS(LCASE(?label), ?query))
+        }
+        #LIMIT#
+    }
+
+    # One UNION branch per independently multi-valued property, and not an OPTIONAL group:
+    # see “One UNION branch per multi-valued property” in the catalog README.
+    {
+        { ?uri a skos:Concept }
+        UNION { ?uri skos:prefLabel ?prefLabel }
+        UNION { ?uri skos:altLabel ?altLabel }
+        UNION { ?uri skos:scopeNote ?scopeNote }
+        UNION { ?uri owl:sameAs ?exactMatch_uri } # Has no labels.
+    }
+}


### PR DESCRIPTION
Adds The House of Legacies persons as a terminology source: 337 terms, each with a persistent ARK identifier resolving through `pid.thehouseoflegacies.nl`.

The House of Legacies is a platform built by Stichting The Need for Legacy, a foundation formed by a young generation of theatre makers of colour working towards an inclusive Dutch theatre history. This list covers the people documented in that archive.

## Source

| | |
| --- | --- |
| SPARQL endpoint | https://terms.thehouseoflegacies.nl/query (public, no authentication) |
| Dataset description | https://terms.thehouseoflegacies.nl/dataset/persons |
| Concept scheme | https://terms.thehouseoflegacies.nl/scheme/persons |
| Terms URI prefix | `https://pid.thehouseoflegacies.nl/ark:43442/` |
| Licence | CC BY 4.0 |
| Permanence policy | https://terms.thehouseoflegacies.nl/policy |

Each term is a `skos:Concept` with a `skos:prefLabel`, plus `skos:altLabel` for the aliases the archive records and `skos:scopeNote` where it holds a biography.

## Files

- `catalog/datasets/hol-persons.jsonld`
- `catalog/queries/search/hol-persons.rq`
- `catalog/queries/lookup/hol-persons.rq`
- `catalog/publishers.jsonld` — one `schema:Organization` entry appended


Happy to adjust anything that does not match house style.
