### PR TITLE
test(graphql): give the schema snapshot time to load the catalog on a slow runner

### DIFF
--- a/packages/graphql/test/schema.test.ts
+++ b/packages/graphql/test/schema.test.ts
@@ -13,5 +13,8 @@ describe('Schema', () => {
     await expect(schema(catalog.getLanguages())).toMatchFileSnapshot(
       '../schema.graphql',
     );
-  }, 30_000);
+    // Loading the catalog parses every dataset file through Comunica, which takes a few seconds
+    // here and 20–30 s on a shared CI runner with other Nx tasks in parallel. Not the network:
+    // the load makes two requests, both for the schema.org context.
+  }, 120_000);
 });


### PR DESCRIPTION
The QA run for the merge of #1968 failed on `graphql:test`: the schema snapshot test timed out at 30 s while loading the catalog. The load is CPU-bound JSON-LD parsing of every dataset file through Comunica – 2.5 s locally, 8 s in a 4-CPU container, 20–30 s on a shared runner with other Nx tasks in parallel – and makes only two HTTP requests, both for the schema.org context, so it is not the network. Same shape as the SHACL test timeout raised in #1968; this raises the snapshot test's timeout the same way.

Making the catalog load itself faster is worth a separate issue: 2.5 s for 57 small files is slow, and the graphql server pays it on every start.